### PR TITLE
feat: implement per-account and cross-chain daily rate limiting for b…

### DIFF
--- a/contracts/bridge/src/errors.rs
+++ b/contracts/bridge/src/errors.rs
@@ -15,6 +15,7 @@ pub enum Error {
     InvalidMetadata,
     DuplicateRequest,
     GasLimitExceeded,
+    RateLimitExceeded,
 }
 
 impl core::fmt::Display for Error {
@@ -32,6 +33,7 @@ impl core::fmt::Display for Error {
             Error::InvalidMetadata => write!(f, "Invalid metadata"),
             Error::DuplicateRequest => write!(f, "Duplicate bridge request"),
             Error::GasLimitExceeded => write!(f, "Gas limit exceeded"),
+            Error::RateLimitExceeded => write!(f, "Rate limit exceeded"),
         }
     }
 }
@@ -51,6 +53,7 @@ impl ContractError for Error {
             Error::InvalidMetadata => bridge_codes::BRIDGE_INVALID_METADATA,
             Error::DuplicateRequest => bridge_codes::BRIDGE_DUPLICATE_REQUEST,
             Error::GasLimitExceeded => bridge_codes::BRIDGE_GAS_LIMIT_EXCEEDED,
+            Error::RateLimitExceeded => bridge_codes::BRIDGE_RATE_LIMIT_EXCEEDED,
         }
     }
 
@@ -72,6 +75,7 @@ impl ContractError for Error {
             Error::InvalidMetadata => "The token metadata is invalid",
             Error::DuplicateRequest => "A bridge request with these parameters already exists",
             Error::GasLimitExceeded => "The operation exceeded the gas limit",
+            Error::RateLimitExceeded => "The operation exceeded the daily rate limit",
         }
     }
 

--- a/contracts/bridge/src/lib.rs
+++ b/contracts/bridge/src/lib.rs
@@ -54,6 +54,18 @@ mod bridge {
 
         /// Pending admin key rotation request
         pending_admin_rotation: Option<propchain_traits::KeyRotationRequest>,
+
+        /// Account daily bridge request count for rate limiting
+        account_daily_requests: Mapping<AccountId, u64>,
+
+        /// Account last reset day for rate limiting
+        account_last_reset_day: Mapping<AccountId, u64>,
+
+        /// Chain daily volume for rate limiting
+        chain_daily_volume: Mapping<ChainId, u128>,
+
+        /// Chain last reset day for rate limiting
+        chain_last_reset_day: Mapping<ChainId, u64>,
     }
 
     /// Events for bridge operations
@@ -127,6 +139,9 @@ mod bridge {
                 gas_limit_per_bridge: gas_limit,
                 emergency_pause: false,
                 metadata_preservation: true,
+                rate_limit_enabled: true,
+                max_requests_per_day: 10,
+                max_value_per_day: 1_000_000_000_000_000_000,
             };
 
             // Initialize chain info for supported chains
@@ -144,6 +159,10 @@ mod bridge {
                 admin: caller,
                 operator_public_keys: Mapping::default(),
                 pending_admin_rotation: None,
+                account_daily_requests: Mapping::default(),
+                account_last_reset_day: Mapping::default(),
+                chain_daily_volume: Mapping::default(),
+                chain_last_reset_day: Mapping::default(),
             };
 
             // Set up default chain information
@@ -156,6 +175,7 @@ mod bridge {
                     gas_multiplier: propchain_traits::constants::DEFAULT_GAS_MULTIPLIER,
                     confirmation_blocks: propchain_traits::constants::DEFAULT_CONFIRMATION_BLOCKS,
                     supported_tokens: Vec::new(),
+                    chain_daily_limit: 10_000_000_000_000_000_000, // Example large default
                 };
                 bridge.chain_info.insert(chain_id, &chain_info);
             }
@@ -197,6 +217,10 @@ mod bridge {
             if !self.is_authorized_for_token(caller, token_id) {
                 return Err(Error::Unauthorized);
             }
+
+            // Enforce rate limiting
+            // For NFT bridge, we count requests but value is 0 here since NFT value isn't strictly defined by amount.
+            self.check_and_update_rate_limits(caller, destination_chain, 0, true)?;
 
             // Create bridge request
             self.request_counter += 1;
@@ -536,6 +560,10 @@ mod bridge {
                 return Err(Error::InvalidChain);
             }
 
+            // Enforce rate limiting
+            // For cross-chain trades, we track the volume (amount_in) but don't count it as an NFT request.
+            self.check_and_update_rate_limits(self.env().caller(), destination_chain, amount_in, false)?;
+
             self.cross_chain_trade_counter += 1;
             let trade_id = self.cross_chain_trade_counter;
             let quote = self.quote_cross_chain_trade(destination_chain, amount_in)?;
@@ -795,6 +823,59 @@ mod bridge {
             let base_gas = 100000; // Base gas for bridge operation
             let metadata_gas = request.metadata.legal_description.len() as u64 * 100; // Gas for metadata
             base_gas + metadata_gas
+        }
+
+        fn check_and_update_rate_limits(
+            &mut self,
+            account: AccountId,
+            destination_chain: ChainId,
+            amount: u128,
+            is_nft: bool,
+        ) -> Result<(), Error> {
+            if !self.config.rate_limit_enabled {
+                return Ok(());
+            }
+
+            let current_day = self.env().block_timestamp() / 86_400_000;
+
+            if is_nft {
+                let last_reset = self.account_last_reset_day.get(account).unwrap_or(0);
+                let mut daily_requests = self.account_daily_requests.get(account).unwrap_or(0);
+
+                if last_reset < current_day {
+                    daily_requests = 0;
+                    self.account_last_reset_day.insert(account, &current_day);
+                }
+
+                if daily_requests >= self.config.max_requests_per_day {
+                    return Err(Error::RateLimitExceeded);
+                }
+
+                self.account_daily_requests.insert(account, &(daily_requests + 1));
+            }
+
+            if amount > 0 {
+                let chain_info = self
+                    .chain_info
+                    .get(destination_chain)
+                    .ok_or(Error::InvalidChain)?;
+                let last_chain_reset = self.chain_last_reset_day.get(destination_chain).unwrap_or(0);
+                let mut chain_volume = self.chain_daily_volume.get(destination_chain).unwrap_or(0);
+
+                if last_chain_reset < current_day {
+                    chain_volume = 0;
+                    self.chain_last_reset_day.insert(destination_chain, &current_day);
+                }
+
+                if chain_volume.saturating_add(amount) > chain_info.chain_daily_limit {
+                    return Err(Error::RateLimitExceeded);
+                }
+
+                self.chain_daily_volume
+                    .insert(destination_chain, &(chain_volume + amount));
+            }
+
+            Ok(())
         }
     }
 

--- a/contracts/traits/src/bridge.rs
+++ b/contracts/traits/src/bridge.rs
@@ -131,6 +131,9 @@ pub struct BridgeConfig {
     pub gas_limit_per_bridge: u64,
     pub emergency_pause: bool,
     pub metadata_preservation: bool,
+    pub rate_limit_enabled: bool,
+    pub max_requests_per_day: u64,
+    pub max_value_per_day: u128,
 }
 
 /// Chain-specific bridge information
@@ -147,6 +150,7 @@ pub struct ChainBridgeInfo {
     pub gas_multiplier: u32,      // Gas cost multiplier for this chain
     pub confirmation_blocks: u32, // Blocks to wait for confirmation
     pub supported_tokens: Vec<TokenId>,
+    pub chain_daily_limit: u128,  // Max volume allowed to be routed to this chain per day
 }
 
 /// Bridge fee quote for cross-chain operations

--- a/contracts/traits/src/errors.rs
+++ b/contracts/traits/src/errors.rs
@@ -298,6 +298,7 @@ pub mod bridge_codes {
     pub const BRIDGE_INVALID_METADATA: u32 = 3010;
     pub const BRIDGE_DUPLICATE_REQUEST: u32 = 3011;
     pub const BRIDGE_GAS_LIMIT_EXCEEDED: u32 = 3012;
+    pub const BRIDGE_RATE_LIMIT_EXCEEDED: u32 = 3013;
 }
 
 /// Oracle error codes (4000-4999)


### PR DESCRIPTION
closes  #200 

Implement Rate Limiting and Liquidity Management for Cross-Chain Bridge
Description
This PR introduces rate limiting to the cross-chain PropertyBridge contract to prevent abuse and carefully manage liquidity across supported chains. The new constraints enforce limits on both the number of bridge requests a user can perform daily and the total volume (amount) of liquidity flowing to specific destination chains.

Changes Made
Traits & Config Updates (contracts/traits/src/bridge.rs):
Expanded BridgeConfig with rate_limit_enabled, max_requests_per_day, and max_value_per_day.
Added chain_daily_limit to ChainBridgeInfo to restrict excessive outflows per chain.
Error Codes (contracts/bridge/src/errors.rs & contracts/traits/src/errors.rs):
Defined a RateLimitExceeded variant to Error.
Added corresponding internal error codes (BRIDGE_RATE_LIMIT_EXCEEDED - 3013) and localized mapping support.
Core Storage and Logic (contracts/bridge/src/lib.rs):
Injected timestamp-based state mappings into PropertyBridge to track daily account request counts and daily chain volumes.
Implemented the check_and_update_rate_limits internal helper, performing threshold validations based on env().block_timestamp().
Enforced the bounds on entry points: initiate_bridge_multisig (tracking NFT bridge requests) and register_cross_chain_trade (tracking raw DEX settlement volume).
Impact
These features ensure that even under heavy activity or potential abuse, the bridge safeguards property liquidity pools by pacing outflows according to globally defined protocol limits.

Testing
 Compilation and Syntax Validation
 Integration Tests for daily resets
 Cross-chain volume cap unit tests