### PR TITLE
feat(di): implement dependency injection framework (#187)

### DIFF
--- a/contracts/lib/src/lib.rs
+++ b/contracts/lib/src/lib.rs
@@ -158,6 +158,12 @@ pub mod propchain_contracts {
         batch_operation_stats: BatchOperationStats,
         /// Comprehensive security audit trail with tamper-evident hash chain
         audit_trail: AuditTrail,
+        /// Dependency injection container — single source of truth for all
+        /// injectable service addresses. Supersedes the individual
+        /// `compliance_registry`, `oracle`, `fee_manager`, and
+        /// `identity_registry` fields for new code; those fields are kept for
+        /// backward-compatibility with existing callers.
+        deps: ContainerConfig,
     }
 
     /// Escrow information
@@ -1093,6 +1099,7 @@ pub mod propchain_contracts {
                     );
                     at
                 },
+                deps: ContainerConfig::new(),
             };
 
             // Emit contract initialization event
@@ -3732,6 +3739,107 @@ pub mod propchain_contracts {
                 return Err(Error::StringTooLong);
             }
             Ok(())
+        }
+    }
+
+    // =========================================================================
+    // Dependency Injection — ServiceRegistry trait implementation
+    // =========================================================================
+
+    /// Emitted whenever a service is registered or unregistered via the DI
+    /// container. Off-chain indexers can use this to track the live service
+    /// topology without reading storage directly.
+    #[ink(event)]
+    pub struct ServiceRegistered {
+        /// The service that was updated.
+        #[ink(topic)]
+        pub key: ServiceKey,
+        /// New address, or `None` when the service was unregistered.
+        pub address: Option<AccountId>,
+        /// Admin account that made the change.
+        #[ink(topic)]
+        pub by: AccountId,
+        pub timestamp: u64,
+    }
+
+    impl ServiceRegistry for PropertyRegistry {
+        /// Register a service address in the DI container (admin only).
+        ///
+        /// Also keeps the legacy individual fields in sync so that existing
+        /// callers that read `oracle()`, `get_compliance_registry()`, etc.
+        /// continue to work without modification.
+        #[ink(message)]
+        fn register_service(
+            &mut self,
+            key: ServiceKey,
+            address: AccountId,
+        ) -> Result<(), DependencyError> {
+            if !self.ensure_admin_rbac() {
+                return Err(DependencyError::Unauthorized);
+            }
+
+            // Delegate validation + storage to ContainerConfig
+            self.deps.register(key, address)?;
+
+            // Keep legacy fields in sync for backward compatibility
+            match key {
+                ServiceKey::Oracle => self.oracle = Some(address),
+                ServiceKey::ComplianceRegistry => self.compliance_registry = Some(address),
+                ServiceKey::FeeManager => self.fee_manager = Some(address),
+                ServiceKey::IdentityRegistry => self.identity_registry = Some(address),
+                _ => {}
+            }
+
+            let caller = self.env().caller();
+            self.env().emit_event(ServiceRegistered {
+                key,
+                address: Some(address),
+                by: caller,
+                timestamp: self.env().block_timestamp(),
+            });
+
+            Ok(())
+        }
+
+        /// Unregister a service from the DI container (admin only).
+        #[ink(message)]
+        fn unregister_service(&mut self, key: ServiceKey) -> Result<(), DependencyError> {
+            if !self.ensure_admin_rbac() {
+                return Err(DependencyError::Unauthorized);
+            }
+
+            self.deps.unregister(key);
+
+            // Keep legacy fields in sync
+            match key {
+                ServiceKey::Oracle => self.oracle = None,
+                ServiceKey::ComplianceRegistry => self.compliance_registry = None,
+                ServiceKey::FeeManager => self.fee_manager = None,
+                ServiceKey::IdentityRegistry => self.identity_registry = None,
+                _ => {}
+            }
+
+            let caller = self.env().caller();
+            self.env().emit_event(ServiceRegistered {
+                key,
+                address: None,
+                by: caller,
+                timestamp: self.env().block_timestamp(),
+            });
+
+            Ok(())
+        }
+
+        /// Resolve a service address by key.
+        #[ink(message)]
+        fn resolve_service(&self, key: ServiceKey) -> Result<AccountId, DependencyError> {
+            self.deps.resolve(key)
+        }
+
+        /// Returns `true` if the service is currently registered.
+        #[ink(message)]
+        fn is_service_registered(&self, key: ServiceKey) -> bool {
+            self.deps.is_registered(key)
         }
     }
 }

--- a/contracts/traits/src/di.rs
+++ b/contracts/traits/src/di.rs
@@ -1,0 +1,286 @@
+//! Dependency Injection framework for PropChain contracts.
+//!
+//! # Overview
+//!
+//! This module provides a lightweight, `no_std`-compatible DI framework
+//! designed for ink! smart contracts. Rather than a runtime container
+//! (impossible on-chain), it offers:
+//!
+//! - [`ServiceKey`] — a typed enum identifying every injectable service.
+//! - [`ServiceRegistry`] — an ink! trait that any contract can implement to
+//!   expose its registered service addresses.
+//! - [`ContainerConfig`] — a plain storage struct that holds all optional
+//!   `AccountId` service addresses and is embedded directly in contract storage.
+//! - [`Injectable`] — a marker trait for contracts that accept injected deps.
+//! - [`DependencyError`] — unified error type for DI operations.
+//!
+//! # Design rationale
+//!
+//! On-chain DI cannot use heap-allocated vtables or dynamic dispatch the way
+//! server-side frameworks do. Instead, each service is identified by a
+//! `ServiceKey` variant and resolved to an `Option<AccountId>` at call time.
+//! Cross-contract calls are then made via ink!'s `CallBuilder` using the
+//! resolved address, keeping coupling at the *address* level rather than the
+//! *type* level.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! // 1. Embed ContainerConfig in your contract storage:
+//! #[ink(storage)]
+//! pub struct MyContract {
+//!     deps: ContainerConfig,
+//!     // ...
+//! }
+//!
+//! // 2. Register services during construction or via admin setter:
+//! deps.register(ServiceKey::Oracle, oracle_address);
+//!
+//! // 3. Resolve at call time:
+//! let oracle_addr = deps.resolve(ServiceKey::Oracle)?;
+//! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use ink::primitives::AccountId;
+
+// =========================================================================
+// Error Type
+// =========================================================================
+
+/// Errors that can occur during dependency injection operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum DependencyError {
+    /// The requested service has not been registered.
+    ServiceNotRegistered,
+    /// Caller is not authorised to modify the service registry.
+    Unauthorized,
+    /// The provided address is the zero address.
+    InvalidAddress,
+}
+
+impl core::fmt::Display for DependencyError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DependencyError::ServiceNotRegistered => {
+                write!(f, "Service not registered in the dependency container")
+            }
+            DependencyError::Unauthorized => {
+                write!(f, "Caller is not authorised to modify the service registry")
+            }
+            DependencyError::InvalidAddress => {
+                write!(f, "Provided address is the zero address")
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Service Key
+// =========================================================================
+
+/// Identifies every injectable service in the PropChain ecosystem.
+///
+/// Add a new variant here whenever a new cross-contract dependency is
+/// introduced. The variant name doubles as documentation for what the
+/// service does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(
+    feature = "std",
+    derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
+)]
+pub enum ServiceKey {
+    /// Property valuation oracle (implements [`Oracle`] trait).
+    Oracle,
+    /// Regulatory compliance checker (implements [`ComplianceChecker`] trait).
+    ComplianceRegistry,
+    /// Dynamic fee provider (implements [`DynamicFeeProvider`] trait).
+    FeeManager,
+    /// Identity / KYC registry.
+    IdentityRegistry,
+    /// Property management workflow contract.
+    PropertyManagement,
+    /// Cross-chain bridge contract.
+    Bridge,
+    /// Insurance pool contract.
+    Insurance,
+    /// Governance / multi-sig contract.
+    Governance,
+}
+
+// =========================================================================
+// ContainerConfig — embeddable storage struct
+// =========================================================================
+
+/// Holds all optional service `AccountId`s for a contract.
+///
+/// Embed this struct directly in your `#[ink(storage)]` struct. It is
+/// intentionally flat (no `Mapping`) so that the full config can be read
+/// in a single storage access.
+///
+/// All fields are `Option<AccountId>` — `None` means "not yet registered".
+/// Use [`ContainerConfig::register`] / [`ContainerConfig::unregister`] to
+/// mutate, and [`ContainerConfig::resolve`] to look up at call time.
+#[ink::storage_item]
+#[derive(Debug, Default)]
+pub struct ContainerConfig {
+    /// Valuation oracle address.
+    pub oracle: Option<AccountId>,
+    /// Compliance registry address.
+    pub compliance_registry: Option<AccountId>,
+    /// Fee manager address.
+    pub fee_manager: Option<AccountId>,
+    /// Identity registry address.
+    pub identity_registry: Option<AccountId>,
+    /// Property management contract address.
+    pub property_management: Option<AccountId>,
+    /// Bridge contract address.
+    pub bridge: Option<AccountId>,
+    /// Insurance contract address.
+    pub insurance: Option<AccountId>,
+    /// Governance contract address.
+    pub governance: Option<AccountId>,
+}
+
+impl ContainerConfig {
+    /// Create a new, empty container (all services unregistered).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register (or replace) a service address.
+    ///
+    /// Returns `Err(DependencyError::InvalidAddress)` if `address` is the
+    /// all-zeros account (a common mistake when passing uninitialized values).
+    pub fn register(
+        &mut self,
+        key: ServiceKey,
+        address: AccountId,
+    ) -> Result<(), DependencyError> {
+        if address == AccountId::from([0u8; 32]) {
+            return Err(DependencyError::InvalidAddress);
+        }
+        match key {
+            ServiceKey::Oracle => self.oracle = Some(address),
+            ServiceKey::ComplianceRegistry => self.compliance_registry = Some(address),
+            ServiceKey::FeeManager => self.fee_manager = Some(address),
+            ServiceKey::IdentityRegistry => self.identity_registry = Some(address),
+            ServiceKey::PropertyManagement => self.property_management = Some(address),
+            ServiceKey::Bridge => self.bridge = Some(address),
+            ServiceKey::Insurance => self.insurance = Some(address),
+            ServiceKey::Governance => self.governance = Some(address),
+        }
+        Ok(())
+    }
+
+    /// Unregister a service (sets it back to `None`).
+    pub fn unregister(&mut self, key: ServiceKey) {
+        match key {
+            ServiceKey::Oracle => self.oracle = None,
+            ServiceKey::ComplianceRegistry => self.compliance_registry = None,
+            ServiceKey::FeeManager => self.fee_manager = None,
+            ServiceKey::IdentityRegistry => self.identity_registry = None,
+            ServiceKey::PropertyManagement => self.property_management = None,
+            ServiceKey::Bridge => self.bridge = None,
+            ServiceKey::Insurance => self.insurance = None,
+            ServiceKey::Governance => self.governance = None,
+        }
+    }
+
+    /// Resolve a service address.
+    ///
+    /// Returns `Ok(AccountId)` if registered, or
+    /// `Err(DependencyError::ServiceNotRegistered)` otherwise.
+    pub fn resolve(&self, key: ServiceKey) -> Result<AccountId, DependencyError> {
+        let opt = match key {
+            ServiceKey::Oracle => self.oracle,
+            ServiceKey::ComplianceRegistry => self.compliance_registry,
+            ServiceKey::FeeManager => self.fee_manager,
+            ServiceKey::IdentityRegistry => self.identity_registry,
+            ServiceKey::PropertyManagement => self.property_management,
+            ServiceKey::Bridge => self.bridge,
+            ServiceKey::Insurance => self.insurance,
+            ServiceKey::Governance => self.governance,
+        };
+        opt.ok_or(DependencyError::ServiceNotRegistered)
+    }
+
+    /// Returns `true` if the given service is currently registered.
+    pub fn is_registered(&self, key: ServiceKey) -> bool {
+        self.resolve(key).is_ok()
+    }
+
+    /// Returns a snapshot of all registered services as `(ServiceKey, AccountId)` pairs.
+    ///
+    /// Useful for admin dashboards and off-chain indexers.
+    pub fn list_registered(&self) -> ink::prelude::vec::Vec<(ServiceKey, AccountId)> {
+        let mut out = ink::prelude::vec::Vec::new();
+        let keys = [
+            ServiceKey::Oracle,
+            ServiceKey::ComplianceRegistry,
+            ServiceKey::FeeManager,
+            ServiceKey::IdentityRegistry,
+            ServiceKey::PropertyManagement,
+            ServiceKey::Bridge,
+            ServiceKey::Insurance,
+            ServiceKey::Governance,
+        ];
+        for key in keys {
+            if let Ok(addr) = self.resolve(key) {
+                out.push((key, addr));
+            }
+        }
+        out
+    }
+}
+
+// =========================================================================
+// ServiceRegistry ink! trait — implement on any contract that exposes DI
+// =========================================================================
+
+/// ink! trait for contracts that expose a service registry.
+///
+/// Implement this on your contract to provide a standard interface for
+/// registering, unregistering, and resolving service dependencies.
+/// Admin-gating of `register_service` / `unregister_service` is the
+/// responsibility of the implementing contract.
+#[ink::trait_definition]
+pub trait ServiceRegistry {
+    /// Register a service address for the given key.
+    ///
+    /// Only callable by the contract admin.
+    #[ink(message)]
+    fn register_service(
+        &mut self,
+        key: ServiceKey,
+        address: AccountId,
+    ) -> Result<(), DependencyError>;
+
+    /// Unregister a service.
+    ///
+    /// Only callable by the contract admin.
+    #[ink(message)]
+    fn unregister_service(&mut self, key: ServiceKey) -> Result<(), DependencyError>;
+
+    /// Resolve a service address by key.
+    ///
+    /// Returns `Err(DependencyError::ServiceNotRegistered)` if not set.
+    #[ink(message)]
+    fn resolve_service(&self, key: ServiceKey) -> Result<AccountId, DependencyError>;
+
+    /// Returns `true` if the service is currently registered.
+    #[ink(message)]
+    fn is_service_registered(&self, key: ServiceKey) -> bool;
+}
+
+// =========================================================================
+// Injectable marker trait
+// =========================================================================
+
+/// Marker trait for contracts that accept injected dependencies.
+///
+/// Implementing this trait signals that the contract uses `ContainerConfig`
+/// internally and honours the `ServiceRegistry` interface. No methods are
+/// required — it exists purely for documentation and potential blanket impls.
+pub trait Injectable: ServiceRegistry {}

--- a/contracts/traits/src/lib.rs
+++ b/contracts/traits/src/lib.rs
@@ -6,11 +6,13 @@
 pub mod access_control;
 pub mod constants;
 pub mod crypto;
+pub mod di;
 pub mod errors;
 pub mod randomness;
 
 pub use access_control::*;
 pub use crypto::*;
+pub use di::*;
 pub mod i18n;
 pub mod monitoring;
 


### PR DESCRIPTION
---

**feat(di): Add dependency injection framework — closes #187**

**Problem**

`PropertyRegistry` and other contracts had scattered `Option<AccountId>` fields (`oracle`, `compliance_registry`, `fee_manager`, `identity_registry`) with no unified way to register, resolve, or introspect service dependencies. This made testing painful — you had to call 4 separate setters and there was no standard interface other contracts could rely on.

**Solution**

A lightweight, `no_std`-compatible DI framework built for ink! contracts. No heap-allocated vtables, no runtime containers — just typed address resolution at call time via ink!'s `CallBuilder`.

**Changes**

`contracts/traits/src/di.rs` (new file)
- `ServiceKey` enum — typed identifier for all 8 injectable services
- `ContainerConfig` — flat `#[ink::storage_item]` struct holding all `Option<AccountId>` service slots; embeds directly in any contract's storage with a single field
- Full CRUD: `register` / `unregister` / `resolve` / `is_registered` / `list_registered` with zero-address guard
- `ServiceRegistry` ink! trait — standard on-chain interface any contract can implement
- `Injectable` marker trait
- `DependencyError` — unified error type

`contracts/traits/src/lib.rs`
- Exposes `pub mod di` + `pub use di::*` — zero changes needed in contracts that already do `use propchain_traits::*`

`contracts/lib/src/lib.rs`
- Adds `deps: ContainerConfig` to `PropertyRegistry` storage
- Implements `ServiceRegistry` trait — `register_service` / `unregister_service` keep the legacy individual fields in sync for full backward compatibility
- Emits `ServiceRegistered` event on every change for off-chain indexers

**Backward compatibility**

All existing callers of `set_oracle()`, `set_compliance_registry()`, `set_fee_manager()`, `set_identity_registry()` continue to work unchanged. The new `register_service(ServiceKey::Oracle, addr)` path is additive.

**Testing**

Run `cargo check -p propchain-traits -p propchain-contracts` — no errors or warnings introduced.