### PR TITLE
Fix cross-chain transfer fee estimation accuracy in bridge quotes

### DIFF
--- a/contracts/bridge/src/lib.rs
+++ b/contracts/bridge/src/lib.rs
@@ -457,11 +457,18 @@ mod bridge {
                 .chain_info
                 .get(destination_chain)
                 .ok_or(Error::InvalidChain)?;
+            if !chain_info.is_active {
+                return Err(Error::InvalidChain);
+            }
 
-            let base_gas = self.config.gas_limit_per_bridge;
-            let multiplier = chain_info.gas_multiplier;
+            let base_gas = propchain_traits::constants::BRIDGE_BASE_GAS;
+            let multiplier = u64::from(chain_info.gas_multiplier);
+            let confirmation_blocks = u64::from(chain_info.confirmation_blocks);
+            let adjusted_base = base_gas.saturating_mul(multiplier) / 100;
+            let confirmation_overhead = adjusted_base.saturating_mul(confirmation_blocks) / 100;
+            let estimated = adjusted_base.saturating_add(confirmation_overhead);
 
-            Ok(base_gas * multiplier as u64 / 100)
+            Ok(estimated.min(self.config.gas_limit_per_bridge))
         }
 
         /// Monitors bridge status
@@ -508,13 +515,30 @@ mod bridge {
             destination_chain: ChainId,
             amount_in: u128,
         ) -> Result<BridgeFeeQuote, Error> {
+            let chain_info = self
+                .chain_info
+                .get(destination_chain)
+                .ok_or(Error::InvalidChain)?;
             let gas_estimate = self.estimate_bridge_gas(0, destination_chain)?;
             let protocol_fee = amount_in / 200;
+            // Convert gas usage into an amount-based fee so totals stay in token units.
+            let gas_fee = if self.config.gas_limit_per_bridge == 0 {
+                0
+            } else {
+                let gas_ratio_bps =
+                    (u128::from(gas_estimate).saturating_mul(10_000))
+                        / u128::from(self.config.gas_limit_per_bridge);
+                let chain_risk_bps = u128::from(chain_info.confirmation_blocks).saturating_mul(10);
+                let adjusted_bps = gas_ratio_bps
+                    .saturating_add(chain_risk_bps)
+                    .min(2_500);
+                amount_in.saturating_mul(adjusted_bps) / 10_000
+            };
             Ok(BridgeFeeQuote {
                 destination_chain,
                 gas_estimate,
                 protocol_fee,
-                total_fee: protocol_fee.saturating_add(gas_estimate as u128),
+                total_fee: protocol_fee.saturating_add(gas_fee),
             })
         }
 

--- a/contracts/bridge/src/tests.rs
+++ b/contracts/bridge/src/tests.rs
@@ -92,4 +92,49 @@ mod tests {
             .expect("settled trade should exist");
         assert_eq!(settled.status, CrossChainTradeStatus::Settled);
     }
+
+    #[ink::test]
+    fn test_estimate_bridge_gas_respects_chain_profile() {
+        let mut bridge = setup_bridge();
+
+        let default_gas = bridge
+            .estimate_bridge_gas(1, 2)
+            .expect("default chain should be estimable");
+
+        let tuned_chain = ChainBridgeInfo {
+            chain_id: 2,
+            chain_name: String::from("High-Confirmation"),
+            bridge_contract_address: None,
+            is_active: true,
+            gas_multiplier: 180,
+            confirmation_blocks: 24,
+            supported_tokens: Vec::new(),
+        };
+        bridge
+            .update_chain_info(2, tuned_chain)
+            .expect("admin should update chain profile");
+
+        let updated_gas = bridge
+            .estimate_bridge_gas(1, 2)
+            .expect("updated chain should be estimable");
+
+        assert!(updated_gas > default_gas);
+        assert!(updated_gas <= bridge.get_config().gas_limit_per_bridge);
+    }
+
+    #[ink::test]
+    fn test_quote_cross_chain_trade_scales_with_amount() {
+        let bridge = setup_bridge();
+
+        let small = bridge
+            .quote_cross_chain_trade(2, 50_000)
+            .expect("small quote should succeed");
+        let large = bridge
+            .quote_cross_chain_trade(2, 100_000)
+            .expect("large quote should succeed");
+
+        assert!(small.total_fee >= small.protocol_fee);
+        assert!(large.total_fee > small.total_fee);
+        assert!(large.protocol_fee > small.protocol_fee);
+    }
 }


### PR DESCRIPTION
## Summary
- make `estimate_bridge_gas` chain-aware by incorporating chain activity, gas multiplier, and confirmation overhead
- keep gas estimates bounded by configured bridge gas limits to preserve existing safety behavior
- fix `quote_cross_chain_trade` fee math so total fees are computed in consistent token amount units instead of mixing raw gas units with token amounts
- add focused bridge tests for chain-profile gas estimation behavior and amount-scaling fee quotes

## Why
Cross-chain fee quotes were previously inaccurate because raw gas units were combined directly with token-denominated fees. This change aligns fee calculation units and improves estimation fidelity while preserving existing bridge flow behavior.

## Test plan
- [x] Run `cargo test -p propchain-bridge`
- [x] Confirm build/test command exits successfully
- [x] Manually review changed files are limited to bridge fee estimation logic and related tests
- [ ] (Optional) Run broader workspace/integration tests before merge

Closes #202 