### PR TITLE
feat: add memory leak monitoring for load tests

### DIFF
--- a/docs/LOAD_TESTING_GUIDE.md
+++ b/docs/LOAD_TESTING_GUIDE.md
@@ -23,10 +23,10 @@ This guide provides comprehensive instructions for running, understanding, and e
 
 ```bash
 # Run all load tests (takes ~30 minutes)
-cargo test --package propchain-tests --test load_tests --release
+cargo test --package propchain-tests --release
 
 # Run with output
-cargo test --package propchain-tests --test load_tests --release -- --nocapture
+cargo test --package propchain-tests --release -- --nocapture
 ```
 
 ### Run Specific Test Categories
@@ -39,10 +39,10 @@ cargo test --package propchain-tests load_test_concurrent_registration --release
 cargo test --package propchain-tests stress_test_ --release --nocapture
 
 # Endurance tests (5-10 minutes)
-cargo test --package propchain-tests endurance_test --release --nocapture
+cargo test --package propchain-tests endurance_test_short --release --nocapture
 
 # Scalability tests (10-15 minutes)
-cargo test --package propchain-tests scalability_test --release --nocapture
+cargo test --package propchain-tests scalability_test_memory_usage --release --nocapture
 ```
 
 ### Quick Performance Check
@@ -201,6 +201,8 @@ run_concurrent_load_test(
 | 1 min    | >96%         | <600ms       | Stable    |
 | 5 min    | >95%         | <800ms       | No degradation |
 
+Endurance runs now sample process RSS during execution and fail if memory growth exceeds the configured leak budget. This makes allocator growth and teardown leaks visible during long-running sessions instead of only at the end of the test.
+
 ### 4. Spike Tests
 
 **Purpose**: Validate system resilience to sudden load changes.
@@ -306,7 +308,7 @@ jobs:
       uses: dtolnay/rust-action@stable
     
     - name: Run Load Tests
-      run: cargo test --package propchain-tests --test load_tests --release
+      run: cargo test --package propchain-tests --release
     
     - name: Upload Results
       uses: actions/upload-artifact@v3
@@ -475,7 +477,7 @@ let config = LoadTestConfig {
 ```rust
 // Profile to identify hotspots
 cargo install flamegraph
-cargo flamegraph --test load_tests --test-threads=1
+cargo flamegraph -p propchain-tests endurance_test_short --test-threads=1
 
 // Check for lock contention
 // Look for long waits in mutex operations
@@ -513,6 +515,9 @@ cargo test --package propchain-tests <test_name> --release -- --test-threads=20
 ```bash
 # Monitor memory usage
 watch -n 1 'ps aux | grep propchain'
+
+# Endurance tests now print peak RSS and memory growth in the test summary
+./scripts/load_test.sh endurance
 
 # Reduce test scale
 let config = LoadTestConfig {

--- a/docs/LOAD_TEST_MONITORING.md
+++ b/docs/LOAD_TEST_MONITORING.md
@@ -242,6 +242,24 @@ fn load_test_with_monitoring() {
 }
 ```
 
+### Memory Leak Detection
+
+For long-running sessions, sample resident set size during the run so leak growth becomes visible before the test finishes.
+
+```rust
+if let Some(rss_mb) = current_process_memory_mb() {
+    metrics.record_peak_memory_mb(rss_mb);
+}
+
+// Compare peak RSS against the baseline captured at test start.
+// Stable endurance runs should stay within the configured leak budget.
+```
+
+Suggested leak budgets:
+- Short endurance runs: peak RSS growth under 24 MB
+- Sustained endurance runs: peak RSS growth under 32 MB
+- Final RSS drift after teardown: close to baseline
+
 ### Alert Conditions
 
 Configure alerts for immediate notification of issues:

--- a/docs/LOAD_TEST_QUICK_START.md
+++ b/docs/LOAD_TEST_QUICK_START.md
@@ -133,6 +133,9 @@ cargo test stress_test_mass_registration --release --nocapture
 
 # Short endurance for CI/CD
 cargo test endurance_test_short --release --nocapture
+
+# Sustained endurance with leak monitoring
+cargo test endurance_test_sustained_load --release --nocapture
 ```
 
 **When to use:** Weekly in staging, before deployments
@@ -145,6 +148,9 @@ cargo test endurance_test_short --release --nocapture
 
 # Database scaling
 cargo test scalability_test_growing_database --release --nocapture
+
+# Memory usage analysis
+cargo test scalability_test_memory_usage --release --nocapture
 ```
 
 **When to use:** Quarterly, capacity planning
@@ -212,7 +218,7 @@ tasklist  # Windows
 3. Profile to find bottlenecks:
 ```bash
 cargo install flamegraph
-cargo flamegraph --test load_tests
+cargo flamegraph -p propchain-tests endurance_test_short
 ```
 
 ### Low Throughput (<50% target)
@@ -323,7 +329,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Run Load Tests
-      run: cargo test --package propchain-tests --test load_tests --release
+      run: cargo test --package propchain-tests --release
 ```
 
 ### Custom Metrics

--- a/scripts/load_test.ps1
+++ b/scripts/load_test.ps1
@@ -74,9 +74,11 @@ function Run-LoadTest {
     Write-Host ""
     
     $cargoArgs = @("test", "--package", $Package, $ReleaseFlag, $OutputFlag)
-    
+
     if ($TestPattern) {
         $cargoArgs += $TestPattern
+    } else {
+        $cargoArgs = @("test", "--package", $Package, $ReleaseFlag, $OutputFlag)
     }
     
     & cargo @cargoArgs
@@ -181,12 +183,12 @@ switch ($Command.ToLower()) {
     
     "endurance" {
         Check-Prerequisites
-        Run-LoadTest -TestPattern "endurance_test" -Description "Endurance Test Suite"
+        Run-LoadTest -TestPattern "endurance_test_" -Description "Endurance Test Suite"
     }
     
     "scalability" {
         Check-Prerequisites
-        Run-LoadTest -TestPattern "scalability_test" -Description "Scalability Test Suite"
+        Run-LoadTest -TestPattern "scalability_test_memory_usage" -Description "Scalability Memory Usage Test"
     }
     
     "mixed" {

--- a/scripts/load_test.sh
+++ b/scripts/load_test.sh
@@ -68,7 +68,7 @@ run_load_test() {
     if [ -n "$test_pattern" ]; then
         cargo test --package "$PACKAGE" $test_pattern $RELEASE_FLAG -- $OUTPUT_FLAG
     else
-        cargo test --package "$PACKAGE" --test load_tests $RELEASE_FLAG -- $OUTPUT_FLAG
+        cargo test --package "$PACKAGE" $RELEASE_FLAG -- $OUTPUT_FLAG
     fi
     
     print_success "Load test completed: $description"
@@ -165,12 +165,12 @@ case "${1:-help}" in
     
     endurance)
         check_prerequisites
-        run_load_test "endurance_test" "Endurance Test Suite"
+        run_load_test "endurance_test_" "Endurance Test Suite"
         ;;
     
     scalability)
         check_prerequisites
-        run_load_test "scalability_test" "Scalability Test Suite"
+        run_load_test "scalability_test_memory_usage" "Scalability Memory Usage Test"
         ;;
     
     mixed)

--- a/tests/load_tests.rs
+++ b/tests/load_tests.rs
@@ -15,19 +15,20 @@
 //!
 //! ```rust,ignore
 //! // Run concurrent registration test
-//! cargo test --package propchain-tests --test load_tests test_concurrent_property_registration --release
+//! cargo test --package propchain-tests load_test_concurrent_registration --release
 //!
 //! // Run stress test with custom concurrency
-//! cargo test --package propchain-tests --test load_tests stress_test_mass_registration --release -- --test-threads=10
+//! cargo test --package propchain-tests stress_test_mass_registration --release -- --test-threads=10
 //!
 //! // Run endurance test
-//! cargo test --package propchain-tests --test load_tests endurance_test_sustained_load --release -- --test-threads=4
+//! cargo test --package propchain-tests endurance_test_sustained_load --release -- --test-threads=4
 //! ```
 
 use ink::env::test::{default_accounts, set_caller};
 use ink_env::DefaultEnvironment;
 use propchain_contracts::propchain_contracts::PropertyRegistry as PropertyRegistryContract;
 use propchain_traits::*;
+use std::fs;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -150,6 +151,14 @@ impl LoadTestMetrics {
         *self.failed_operations.lock().unwrap() += 1;
     }
 
+    /// Update the recorded peak memory usage.
+    pub fn record_peak_memory_mb(&self, memory_mb: f64) {
+        let mut peak = self.peak_memory_mb.lock().unwrap();
+        if memory_mb > *peak {
+            *peak = memory_mb;
+        }
+    }
+
     /// Calculate average response time
     pub fn avg_response_time_ms(&self) -> f64 {
         let total_ops = *self.successful_operations.lock().unwrap();
@@ -203,6 +212,10 @@ impl LoadTestMetrics {
         println!(
             "Ops/Second:            {:.2}",
             *self.ops_per_second.lock().unwrap()
+        );
+        println!(
+            "Peak Memory:           {:.2} MB",
+            *self.peak_memory_mb.lock().unwrap()
         );
         println!("{}", "=".repeat(80));
     }
@@ -409,7 +422,251 @@ pub fn assert_performance_thresholds(
     println!("✅ All performance thresholds met!");
 }
 
+/// Return the current process resident set size in megabytes when available.
+fn current_process_memory_mb() -> Option<f64> {
+    #[cfg(target_os = "linux")]
+    {
+        let status = fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(value) = line.strip_prefix("VmRSS:") {
+                let kib = value.split_whitespace().next()?.parse::<f64>().ok()?;
+                return Some(kib / 1024.0);
+            }
+        }
+        None
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MemorySample {
+    elapsed_secs: f64,
+    rss_mb: f64,
+}
+
+#[derive(Debug)]
+struct MemoryLeakReport {
+    baseline_rss_mb: f64,
+    peak_rss_mb: f64,
+    final_rss_mb: f64,
+    samples: Vec<MemorySample>,
+}
+
+impl MemoryLeakReport {
+    fn growth_mb(&self) -> f64 {
+        self.peak_rss_mb - self.baseline_rss_mb
+    }
+}
+
+struct MemoryLeakMonitor {
+    samples: Arc<Mutex<Vec<MemorySample>>>,
+    peak_rss_mb: Arc<Mutex<f64>>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl MemoryLeakMonitor {
+    fn start(sample_interval: Duration) -> Option<Self> {
+        let baseline_rss_mb = current_process_memory_mb()?;
+        let samples = Arc::new(Mutex::new(vec![MemorySample {
+            elapsed_secs: 0.0,
+            rss_mb: baseline_rss_mb,
+        }]));
+        let peak_rss_mb = Arc::new(Mutex::new(baseline_rss_mb));
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let start_time = Instant::now();
+
+        let samples_clone = Arc::clone(&samples);
+        let peak_clone = Arc::clone(&peak_rss_mb);
+        let stop_clone = Arc::clone(&stop);
+        let handle = thread::spawn(move || {
+            while !stop_clone.load(std::sync::atomic::Ordering::SeqCst) {
+                thread::sleep(sample_interval);
+                if let Some(rss_mb) = current_process_memory_mb() {
+                    let elapsed_secs = start_time.elapsed().as_secs_f64();
+                    samples_clone.lock().unwrap().push(MemorySample {
+                        elapsed_secs,
+                        rss_mb,
+                    });
+                    let mut peak = peak_clone.lock().unwrap();
+                    if rss_mb > *peak {
+                        *peak = rss_mb;
+                    }
+                }
+            }
+        });
+
+        Some(Self {
+            samples,
+            peak_rss_mb,
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    fn finish(mut self) -> MemoryLeakReport {
+        self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("memory monitor thread should stop");
+        }
+
+        let samples = self.samples.lock().unwrap().clone();
+        let baseline_rss_mb = samples
+            .first()
+            .map(|sample| sample.rss_mb)
+            .unwrap_or_default();
+        let final_rss_mb = samples
+            .last()
+            .map(|sample| sample.rss_mb)
+            .unwrap_or(baseline_rss_mb);
+        let peak_rss_mb = *self.peak_rss_mb.lock().unwrap();
+
+        MemoryLeakReport {
+            baseline_rss_mb,
+            peak_rss_mb,
+            final_rss_mb,
+            samples,
+        }
+    }
+
+    fn record_current_peak(&self, metrics: &LoadTestMetrics) {
+        if let Some(rss_mb) = current_process_memory_mb() {
+            metrics.record_peak_memory_mb(rss_mb);
+        }
+    }
+}
+
+fn assert_memory_growth_bounded(
+    report: &MemoryLeakReport,
+    test_name: &str,
+    max_growth_mb: f64,
+    max_final_drift_mb: f64,
+) {
+    let growth_mb = report.growth_mb();
+    let final_drift_mb = report.final_rss_mb - report.baseline_rss_mb;
+
+    println!("\n🧠 Memory Leak Check: {}", test_name);
+    println!(
+        "  Baseline RSS: {:.2} MB | Peak RSS: {:.2} MB | Final RSS: {:.2} MB",
+        report.baseline_rss_mb, report.peak_rss_mb, report.final_rss_mb
+    );
+    println!(
+        "  Growth: {:.2} MB (max {:.2} MB) | Final drift: {:.2} MB (max {:.2} MB)",
+        growth_mb, max_growth_mb, final_drift_mb, max_final_drift_mb
+    );
+    if let Some(last_sample) = report.samples.last() {
+        println!("  Sample Span: {:.2} sec", last_sample.elapsed_secs);
+    }
+    println!("  Samples captured: {}", report.samples.len());
+
+    assert!(
+        growth_mb <= max_growth_mb,
+        "memory growth {:.2} MB exceeds threshold {:.2} MB",
+        growth_mb,
+        max_growth_mb
+    );
+    assert!(
+        final_drift_mb <= max_final_drift_mb,
+        "final RSS drift {:.2} MB exceeds threshold {:.2} MB",
+        final_drift_mb,
+        max_final_drift_mb
+    );
+}
+
+fn run_memory_hygiene_session(
+    iterations: usize,
+    properties_per_cycle: usize,
+    delay_ms: u64,
+    monitor_interval_ms: u64,
+) -> (LoadTestMetrics, MemoryLeakReport) {
+    let metrics = LoadTestMetrics::default();
+    let monitor = MemoryLeakMonitor::start(Duration::from_millis(monitor_interval_ms))
+        .expect("memory monitoring requires a supported platform");
+    let start = Instant::now();
+    let accounts = default_accounts::<DefaultEnvironment>();
+
+    for cycle in 0..iterations {
+        let caller = match cycle % 5 {
+            0 => accounts.alice,
+            1 => accounts.bob,
+            2 => accounts.charlie,
+            3 => accounts.django,
+            _ => accounts.eve,
+        };
+        set_caller::<DefaultEnvironment>(caller);
+
+        let mut registry = PropertyRegistryContract::new();
+
+        for property in 0..properties_per_cycle {
+            let operation_start = Instant::now();
+            let metadata = generate_property_metadata(cycle, property);
+            registry
+                .register_property(metadata)
+                .expect("property registration should succeed");
+
+            let elapsed = operation_start.elapsed().as_millis();
+            metrics.record_success(elapsed);
+            monitor.record_current_peak(&metrics);
+        }
+
+        let query_start = Instant::now();
+        let _ = registry.get_owner_properties(caller);
+        metrics.record_success(query_start.elapsed().as_millis());
+        monitor.record_current_peak(&metrics);
+
+        if delay_ms > 0 {
+            thread::sleep(Duration::from_millis(delay_ms));
+        }
+    }
+
+    let elapsed_secs = start.elapsed().as_secs_f64().max(0.001);
+    let total_ops = *metrics.total_operations.lock().unwrap() as f64;
+    *metrics.ops_per_second.lock().unwrap() = total_ops / elapsed_secs;
+
+    let report = monitor.finish();
+    metrics.record_peak_memory_mb(report.peak_rss_mb);
+    (metrics, report)
+}
+
 // ── API Rate Limit Tests (Issue #162) ─────────────────────────────────────────
+
+#[cfg(test)]
+mod memory_leak_monitoring_tests {
+    use super::*;
+
+    #[test]
+    fn endurance_test_short() {
+        let (metrics, report) = run_memory_hygiene_session(18, 3, 15, 100);
+        metrics.print_summary("Endurance Test - Short");
+        assert_memory_growth_bounded(&report, "Endurance Test - Short", 24.0, 12.0);
+        assert!(
+            metrics.success_rate() >= 95.0,
+            "short endurance session should remain stable"
+        );
+    }
+
+    #[test]
+    fn endurance_test_sustained_load() {
+        let (metrics, report) = run_memory_hygiene_session(40, 4, 10, 100);
+        metrics.print_summary("Endurance Test - Sustained Load");
+        assert_memory_growth_bounded(&report, "Endurance Test - Sustained Load", 32.0, 16.0);
+        assert!(
+            *metrics.ops_per_second.lock().unwrap() > 0.0,
+            "sustained load should record throughput"
+        );
+    }
+
+    #[test]
+    fn scalability_test_memory_usage() {
+        let (metrics, report) = run_memory_hygiene_session(24, 6, 5, 100);
+        metrics.print_summary("Scalability Test - Memory Usage");
+        assert_memory_growth_bounded(&report, "Scalability Test - Memory Usage", 28.0, 14.0);
+    }
+}
 
 #[cfg(test)]
 mod api_rate_limit_tests {


### PR DESCRIPTION
 # Add memory leak monitoring for long-running load tests

  Description
  This PR adds memory leak monitoring to the PropChain load-test suite so long-running endurance runs can detect RSS growth and teardown
  drift, not just throughput regressions.

  What changed

  - Added a lightweight process RSS sampler to tests/load_tests.rs
  - Added memory growth reporting and bounded leak assertions for endurance/scalability sessions
  - Added new long-running test coverage:
      - endurance_test_short
      - endurance_test_sustained_load
      - scalability_test_memory_usage
  - Updated the load-test runners to invoke the correct library test targets
  - Updated load-testing docs to reflect the new endurance/memory monitoring workflow and thresholds

  Behavior

  - Endurance tests now record peak RSS during execution
  - Tests fail if memory growth or final RSS drift exceeds the configured budget
  - Summaries now include peak memory usage in MB

  Docs updated

  - docs/LOAD_TESTING_GUIDE.md
  - docs/LOAD_TEST_QUICK_START.md
  - docs/LOAD_TEST_MONITORING.md

  Verification

  - cargo fmt --all --check
  - Attempted cargo test -p propchain-tests endurance_test_short --release -- --nocapture
  - Full test compile is currently blocked by an unrelated existing syntax error in contracts/property-token/src/types.rs
  

closes #159 