### PR TITLE
Feature/add swagger specifics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4144,6 +4154,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -5542,6 +5563,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -5922,6 +5945,40 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.116",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
 ]
 
 [[package]]
@@ -6881,6 +6938,12 @@ dependencies = [
  "paste",
  "wide",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple-mermaid"
@@ -8753,6 +8816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8855,6 +8924,49 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.116",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4b5ac679cc6dfc5ea3f2823b0291c777750ffd5e13b21137e0f7ac0e8f9617"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
 
 [[package]]
 name = "uuid"
@@ -9917,9 +10029,11 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
+ "flate2",
  "indexmap 2.13.0",
  "memchr",
  "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]
@@ -9927,3 +10041,15 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [features]
 default = []
 # ingest feature broken with subxt 0.33 - requires API update
+ingest = []
 # ingest = ["subxt"]
 
 [dependencies]

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -30,4 +30,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.8", features = ["v4", "serde"] }
 # subxt = { version = "0.33", optional = true }
 url = "2.5"
+utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
+utoipa-swagger-ui = { version = "8", features = ["axum"] }
 

--- a/indexer/README.md
+++ b/indexer/README.md
@@ -21,7 +21,13 @@ API
 - GET /events
   - Query params: `contract`, `event_type`, `topic`, `from_ts`, `to_ts`, `from_block`, `to_block`, `limit`, `offset`
   - `from_ts`/`to_ts` use RFC3339 timestamps
+- GET /contracts
 - GET /metrics (Prometheus)
+
+API Documentation
+
+- Swagger UI: http://localhost:8088/swagger-ui/
+- OpenAPI JSON: http://localhost:8088/api-docs/openapi.json
 
 Storage layout
 

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -8,23 +8,54 @@ pub struct ApiState {
     pub db: Arc<Db>,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, utoipa::IntoParams, utoipa::ToSchema)]
+#[into_params(parameter_in = Query)]
 pub struct EventsParams {
+    /// Filter by contract address
     pub contract: Option<String>,
+    /// Filter by event type name
     pub event_type: Option<String>,
+    /// Filter by a topic value (matches any element in the topics array)
     pub topic: Option<String>,
+    /// Lower bound timestamp (RFC3339)
     pub from_ts: Option<String>,
+    /// Upper bound timestamp (RFC3339)
     pub to_ts: Option<String>,
+    /// Lower bound block number (inclusive)
     pub from_block: Option<i64>,
+    /// Upper bound block number (inclusive)
     pub to_block: Option<i64>,
+    /// Max records to return (1–1000, default 100)
+    #[param(minimum = 1, maximum = 1000)]
     pub limit: Option<i64>,
+    /// Number of records to skip (>= 0)
+    #[param(minimum = 0)]
     pub offset: Option<i64>,
 }
 
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "System",
+    responses(
+        (status = 200, description = "Service is healthy", body = String)
+    )
+)]
 pub async fn health() -> &'static str {
     "ok"
 }
 
+#[utoipa::path(
+    get,
+    path = "/events",
+    tag = "Events",
+    params(EventsParams),
+    responses(
+        (status = 200, description = "Paginated list of indexed contract events", body = Vec<IndexedEvent>),
+        (status = 400, description = "Invalid query parameters"),
+        (status = 500, description = "Database error")
+    )
+)]
 pub async fn list_events(
     state: axum::extract::State<ApiState>,
     Query(params): Query<EventsParams>,
@@ -97,6 +128,15 @@ pub async fn list_events(
     Ok(Json(res))
 }
 
+#[utoipa::path(
+    get,
+    path = "/contracts",
+    tag = "Events",
+    responses(
+        (status = 200, description = "Distinct list of contract addresses with indexed events", body = Vec<String>),
+        (status = 500, description = "Database error")
+    )
+)]
 pub async fn list_contracts(
     state: axum::extract::State<ApiState>,
 ) -> Result<Json<Vec<String>>, (StatusCode, String)> {

--- a/indexer/src/db.rs
+++ b/indexer/src/db.rs
@@ -114,15 +114,18 @@ pub struct EventQuery {
     pub offset: Option<i64>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct IndexedEvent {
+    /// Unique record identifier (UUID v4)
     pub id: Uuid,
     pub block_number: i64,
     pub block_hash: String,
+    /// RFC3339 timestamp of the block
     pub block_timestamp: DateTime<Utc>,
     pub contract: String,
     pub event_type: Option<String>,
     pub topics: Option<Vec<String>>,
+    /// Raw event payload as hex-encoded bytes
     pub payload_hex: String,
 }
 

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -2,8 +2,10 @@ mod api;
 mod db;
 #[cfg(feature = "ingest")]
 mod ingest;
+mod openapi;
 
 use crate::api::{health, list_events, ApiState};
+use crate::openapi::ApiDoc;
 use anyhow::Context;
 use axum::{routing::get, Router};
 use axum_prometheus::PrometheusMetricLayer;
@@ -14,6 +16,8 @@ use tokio::net::TcpListener;
 use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::cors::{Any, CorsLayer};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
 #[derive(Parser, Debug)]
 #[command(name = "propchain-indexer")]
@@ -78,12 +82,16 @@ async fn main() -> anyhow::Result<()> {
 
     let api_state = ApiState { db: db.clone() };
 
-    let app = Router::new()
+    let api_routes = Router::new()
         .route("/health", get(health))
         .route("/events", get(list_events))
         .route("/contracts", get(crate::api::list_contracts))
         .route("/metrics", get(|| async move { metric_handle.render() }))
-        .with_state(api_state)
+        .with_state(api_state);
+
+    let app = Router::new()
+        .merge(api_routes)
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .layer(prometheus_layer)
         .layer(cors)
         .layer(governor_layer);

--- a/indexer/src/openapi.rs
+++ b/indexer/src/openapi.rs
@@ -1,0 +1,23 @@
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "PropChain Indexer API",
+        version = "0.1.0",
+        description = "Query API for indexed PropChain smart contract events on Substrate/Polkadot."
+    ),
+    paths(
+        crate::api::health,
+        crate::api::list_events,
+        crate::api::list_contracts,
+    ),
+    components(
+        schemas(crate::db::IndexedEvent, crate::api::EventsParams)
+    ),
+    tags(
+        (name = "System", description = "Service health"),
+        (name = "Events", description = "Contract event queries")
+    )
+)]
+pub struct ApiDoc;


### PR DESCRIPTION
# Closes #178 

## ✨ Feature: OpenAPI/Swagger Specification for Indexer REST API ([#178](#))

### Goal

Add a machine-readable OpenAPI/Swagger specification to the PropChain indexer REST API so consumers can explore, test, and generate clients against the API without relying solely on the markdown README.

---

### 🔍 What Was Implemented

The `utoipa` crate was integrated into the indexer to derive an **OpenAPI 3.0 spec at compile time** from code annotations. A Swagger UI is served at `/swagger-ui/` and the raw JSON spec at `/api-docs/openapi.json`.

The three documented routes are:

| Route | Method |
|-------|--------|
| `/health` | `GET` |
| `/events` | `GET` |
| `/contracts` | `GET` |

> **Note:** `/metrics` is intentionally excluded as it returns Prometheus text, not JSON.

---

### 📁 Files Modified

| File | Change |
|------|--------|
| `indexer/Cargo.toml` | Added `utoipa` v5 and `utoipa-swagger-ui` v8 dependencies; declared `ingest` as a valid feature to fix pre-existing clippy warnings |
| `indexer/src/db.rs` | Added `utoipa::ToSchema` derive and doc comments to `IndexedEvent` |
| `indexer/src/api.rs` | Added `utoipa::IntoParams` + `utoipa::ToSchema` to `EventsParams`; added `#[utoipa::path]` annotations to `health`, `list_events`, and `list_contracts` handlers |
| `indexer/src/openapi.rs` | **New file** — `ApiDoc` struct that assembles the full OpenAPI spec (paths, schemas, tags, info) |
| `indexer/src/main.rs` | Added `mod openapi`; restructured router to merge `SwaggerUi` as a stateless outer layer alongside the state-bearing API routes |
| `indexer/README.md` | Added Swagger UI and OpenAPI JSON URLs under a new "API Documentation" section |