### PR TITLE
feat: identity audit trail, revocation, oracle milestone release, refund policy

### DIFF
--- a/contracts/crowdfunding/src/lib.rs
+++ b/contracts/crowdfunding/src/lib.rs
@@ -30,6 +30,7 @@ mod propchain_crowdfunding {
         InvalidParameters,
         AlreadyVoted,
         ReentrantCall,
+
         OracleVerificationFailed,
         CampaignNotFailed,
         AlreadyRefunded,
@@ -544,7 +545,11 @@ mod propchain_crowdfunding {
                 if campaign.status != CampaignStatus::Cancelled {
                     return Err(CrowdfundingError::CampaignNotFailed);
                 }
-                if self.refunds_issued.get((campaign_id, caller)).unwrap_or(false) {
+                if self
+                    .refunds_issued
+                    .get((campaign_id, caller))
+                    .unwrap_or(false)
+                {
                     return Err(CrowdfundingError::AlreadyRefunded);
                 }
                 let amount = self

--- a/contracts/crowdfunding/src/lib.rs
+++ b/contracts/crowdfunding/src/lib.rs
@@ -30,6 +30,10 @@ mod propchain_crowdfunding {
         InvalidParameters,
         AlreadyVoted,
         ReentrantCall,
+        OracleVerificationFailed,
+        CampaignNotFailed,
+        AlreadyRefunded,
+        NoInvestmentFound,
     }
 
     impl From<propchain_traits::ReentrancyError> for CrowdfundingError {
@@ -161,6 +165,8 @@ mod propchain_crowdfunding {
         pub description: String,
         pub release_amount: u128,
         pub status: MilestoneStatus,
+        pub oracle_verified: bool,
+        pub oracle_data_hash: Option<[u8; 32]>,
     }
 
     #[derive(
@@ -219,6 +225,10 @@ mod propchain_crowdfunding {
         risk_profiles: Mapping<u64, RiskProfile>,
         blocked_jurisdictions: Vec<String>,
         reentrancy_guard: propchain_traits::ReentrancyGuard,
+        /// Authorized oracle accounts for milestone verification
+        authorized_oracles: Mapping<AccountId, bool>,
+        /// Tracks whether an investor has been refunded for a campaign
+        refunds_issued: Mapping<(u64, AccountId), bool>,
     }
 
     #[ink(event)]
@@ -263,6 +273,24 @@ mod propchain_crowdfunding {
         shares: u64,
     }
 
+    #[ink(event)]
+    pub struct MilestoneOracleVerified {
+        #[ink(topic)]
+        milestone_id: u64,
+        #[ink(topic)]
+        oracle: AccountId,
+        data_hash: [u8; 32],
+    }
+
+    #[ink(event)]
+    pub struct RefundIssued {
+        #[ink(topic)]
+        campaign_id: u64,
+        #[ink(topic)]
+        investor: AccountId,
+        amount: u128,
+    }
+
     impl RealEstateCrowdfunding {
         #[ink(constructor)]
         pub fn new(admin: AccountId) -> Self {
@@ -284,6 +312,8 @@ mod propchain_crowdfunding {
                 risk_profiles: Mapping::default(),
                 blocked_jurisdictions: Vec::new(),
                 reentrancy_guard: propchain_traits::ReentrancyGuard::new(),
+                authorized_oracles: Mapping::default(),
+                refunds_issued: Mapping::default(),
             }
         }
 
@@ -407,6 +437,8 @@ mod propchain_crowdfunding {
                 description,
                 release_amount,
                 status: MilestoneStatus::Pending,
+                oracle_verified: false,
+                oracle_data_hash: None,
             };
             self.milestones.insert(self.milestone_count, &milestone);
             Ok(self.milestone_count)
@@ -440,10 +472,104 @@ mod propchain_crowdfunding {
                 if milestone.status != MilestoneStatus::Approved {
                     return Err(CrowdfundingError::MilestoneNotApproved);
                 }
+                if !milestone.oracle_verified {
+                    return Err(CrowdfundingError::OracleVerificationFailed);
+                }
                 milestone.status = MilestoneStatus::Released;
                 self.milestones.insert(milestone_id, &milestone);
                 Ok(())
             })
+        }
+
+        /// Oracle submits verification for a milestone (oracle only)
+        #[ink(message)]
+        pub fn oracle_verify_milestone(
+            &mut self,
+            milestone_id: u64,
+            data_hash: [u8; 32],
+        ) -> Result<(), CrowdfundingError> {
+            let caller = self.env().caller();
+            if !self.authorized_oracles.get(caller).unwrap_or(false) && caller != self.admin {
+                return Err(CrowdfundingError::Unauthorized);
+            }
+            let mut milestone = self
+                .milestones
+                .get(milestone_id)
+                .ok_or(CrowdfundingError::MilestoneNotFound)?;
+            milestone.oracle_verified = true;
+            milestone.oracle_data_hash = Some(data_hash);
+            self.milestones.insert(milestone_id, &milestone);
+            self.env().emit_event(MilestoneOracleVerified {
+                milestone_id,
+                oracle: caller,
+                data_hash,
+            });
+            Ok(())
+        }
+
+        /// Admin: authorize an oracle account
+        #[ink(message)]
+        pub fn add_oracle(&mut self, oracle: AccountId) -> Result<(), CrowdfundingError> {
+            if self.env().caller() != self.admin {
+                return Err(CrowdfundingError::Unauthorized);
+            }
+            self.authorized_oracles.insert(oracle, &true);
+            Ok(())
+        }
+
+        /// Mark a campaign as failed/cancelled and enable refunds (admin only)
+        #[ink(message)]
+        pub fn fail_campaign(&mut self, campaign_id: u64) -> Result<(), CrowdfundingError> {
+            if self.env().caller() != self.admin {
+                return Err(CrowdfundingError::Unauthorized);
+            }
+            let mut campaign = self
+                .campaigns
+                .get(campaign_id)
+                .ok_or(CrowdfundingError::CampaignNotFound)?;
+            campaign.status = CampaignStatus::Cancelled;
+            self.campaigns.insert(campaign_id, &campaign);
+            Ok(())
+        }
+
+        /// Investor claims a refund for a failed/cancelled campaign
+        #[ink(message)]
+        pub fn claim_refund(&mut self, campaign_id: u64) -> Result<u128, CrowdfundingError> {
+            propchain_traits::non_reentrant!(self, {
+                let caller = self.env().caller();
+                let campaign = self
+                    .campaigns
+                    .get(campaign_id)
+                    .ok_or(CrowdfundingError::CampaignNotFound)?;
+                if campaign.status != CampaignStatus::Cancelled {
+                    return Err(CrowdfundingError::CampaignNotFailed);
+                }
+                if self.refunds_issued.get((campaign_id, caller)).unwrap_or(false) {
+                    return Err(CrowdfundingError::AlreadyRefunded);
+                }
+                let amount = self
+                    .investments
+                    .get((campaign_id, caller))
+                    .ok_or(CrowdfundingError::NoInvestmentFound)?;
+                if amount == 0 {
+                    return Err(CrowdfundingError::NoInvestmentFound);
+                }
+                self.refunds_issued.insert((campaign_id, caller), &true);
+                self.env().emit_event(RefundIssued {
+                    campaign_id,
+                    investor: caller,
+                    amount,
+                });
+                Ok(amount)
+            })
+        }
+
+        /// Check if an investor has been refunded for a campaign
+        #[ink(message)]
+        pub fn is_refunded(&self, campaign_id: u64, investor: AccountId) -> bool {
+            self.refunds_issued
+                .get((campaign_id, investor))
+                .unwrap_or(false)
         }
 
         #[ink(message)]
@@ -736,8 +862,110 @@ mod tests {
         let milestone_id = contract
             .add_milestone(campaign_id, "Foundation".into(), 50_000)
             .unwrap();
+        // Oracle must verify before release
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.add_oracle(accounts.alice).unwrap();
+        contract
+            .oracle_verify_milestone(milestone_id, [1u8; 32])
+            .unwrap();
         assert!(contract.approve_milestone(milestone_id).is_ok());
         assert!(contract.release_milestone(milestone_id).is_ok());
+    }
+
+    #[ink::test]
+    fn test_release_milestone_requires_oracle_verification() {
+        let mut contract = setup();
+        let campaign_id = contract
+            .create_campaign("Park Place".into(), 200_000)
+            .unwrap();
+        let milestone_id = contract
+            .add_milestone(campaign_id, "Foundation".into(), 50_000)
+            .unwrap();
+        contract.approve_milestone(milestone_id).unwrap();
+        // Release without oracle verification should fail
+        assert_eq!(
+            contract.release_milestone(milestone_id),
+            Err(CrowdfundingError::OracleVerificationFailed)
+        );
+    }
+
+    #[ink::test]
+    fn test_oracle_verify_milestone() {
+        let mut contract = setup();
+        let campaign_id = contract
+            .create_campaign("Park Place".into(), 200_000)
+            .unwrap();
+        let milestone_id = contract
+            .add_milestone(campaign_id, "Foundation".into(), 50_000)
+            .unwrap();
+        // Admin can act as oracle
+        assert!(contract
+            .oracle_verify_milestone(milestone_id, [2u8; 32])
+            .is_ok());
+        let milestone = contract.get_milestone(milestone_id).unwrap();
+        assert!(milestone.oracle_verified);
+        assert_eq!(milestone.oracle_data_hash, Some([2u8; 32]));
+    }
+
+    #[ink::test]
+    fn test_refund_policy_failed_campaign() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let campaign_id = contract
+            .create_campaign("Sunset Villas".into(), 100_000)
+            .unwrap();
+        contract.activate_campaign(campaign_id).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        contract.onboard_investor("US".into(), true).unwrap();
+        contract.invest(campaign_id, 40_000).unwrap();
+        // Admin marks campaign as failed
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        assert!(contract.fail_campaign(campaign_id).is_ok());
+        // Bob claims refund
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let refund = contract.claim_refund(campaign_id).unwrap();
+        assert_eq!(refund, 40_000);
+        assert!(contract.is_refunded(campaign_id, accounts.bob));
+    }
+
+    #[ink::test]
+    fn test_refund_not_allowed_for_active_campaign() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let campaign_id = contract
+            .create_campaign("Sunset Villas".into(), 100_000)
+            .unwrap();
+        contract.activate_campaign(campaign_id).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        contract.onboard_investor("US".into(), true).unwrap();
+        contract.invest(campaign_id, 40_000).unwrap();
+        // Refund should fail for active campaign
+        assert_eq!(
+            contract.claim_refund(campaign_id),
+            Err(CrowdfundingError::CampaignNotFailed)
+        );
+    }
+
+    #[ink::test]
+    fn test_double_refund_not_allowed() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let campaign_id = contract
+            .create_campaign("Sunset Villas".into(), 100_000)
+            .unwrap();
+        contract.activate_campaign(campaign_id).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        contract.onboard_investor("US".into(), true).unwrap();
+        contract.invest(campaign_id, 40_000).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract.fail_campaign(campaign_id).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        contract.claim_refund(campaign_id).unwrap();
+        // Second refund should fail
+        assert_eq!(
+            contract.claim_refund(campaign_id),
+            Err(CrowdfundingError::AlreadyRefunded)
+        );
     }
 
     #[ink::test]

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -1283,8 +1283,7 @@ pub mod propchain_identity {
         #[ink::test]
         fn test_audit_trail_on_create() {
             let mut reg = default_registry();
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
             assert_eq!(reg.get_audit_count(), 0);
             reg.create_identity(
                 "did:test:audit1".into(),
@@ -1303,8 +1302,7 @@ pub mod propchain_identity {
         #[ink::test]
         fn test_audit_trail_on_verify() {
             let mut reg = default_registry();
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
             reg.create_identity(
                 "did:test:audit2".into(),
                 vec![1u8; 32],
@@ -1325,8 +1323,7 @@ pub mod propchain_identity {
         #[ink::test]
         fn test_revoke_identity() {
             let mut reg = default_registry();
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
             // Create identity as bob
             ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
             reg.create_identity(
@@ -1355,8 +1352,7 @@ pub mod propchain_identity {
         #[ink::test]
         fn test_revoke_unauthorized() {
             let mut reg = default_registry();
-            let accounts =
-                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            let accounts = ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
             reg.create_identity(
                 "did:test:revoke2".into(),
                 vec![1u8; 32],

--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -50,6 +50,34 @@ pub mod propchain_identity {
         UnsupportedChain,
         /// Cross-chain verification failed
         CrossChainVerificationFailed,
+        /// Identity has been revoked
+        IdentityRevoked,
+    }
+
+    /// Audit trail entry for identity operations
+    #[derive(
+        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct AuditEntry {
+        pub entry_id: u64,
+        pub account: AccountId,
+        pub action: String,
+        pub performed_by: AccountId,
+        pub timestamp: u64,
+        pub details: String,
+    }
+
+    /// Revocation record for a revoked identity
+    #[derive(
+        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct RevocationRecord {
+        pub account: AccountId,
+        pub revoked_by: AccountId,
+        pub reason: String,
+        pub revoked_at: u64,
     }
 
     /// Decentralized Identifier (DID) document structure
@@ -264,6 +292,16 @@ pub mod propchain_identity {
         version: u32,
         /// Privacy verification nonces
         privacy_nonces: Mapping<AccountId, u64>,
+        /// Audit trail entries indexed by entry id
+        audit_trail: Mapping<u64, AuditEntry>,
+        /// Audit entry counter
+        audit_count: u64,
+        /// Per-account audit entry index list (stores entry ids)
+        account_audit_index: Mapping<(AccountId, u64), u64>,
+        /// Per-account audit entry count
+        account_audit_count: Mapping<AccountId, u64>,
+        /// Revocation records for revoked identities
+        revocations: Mapping<AccountId, RevocationRecord>,
     }
 
     /// Events
@@ -335,6 +373,25 @@ pub mod propchain_identity {
         timestamp: u64,
     }
 
+    #[ink(event)]
+    pub struct IdentityRevoked {
+        #[ink(topic)]
+        account: AccountId,
+        #[ink(topic)]
+        revoked_by: AccountId,
+        reason: String,
+        timestamp: u64,
+    }
+
+    #[ink(event)]
+    pub struct AuditEntryAdded {
+        #[ink(topic)]
+        account: AccountId,
+        entry_id: u64,
+        action: String,
+        timestamp: u64,
+    }
+
     impl Default for IdentityRegistry {
         fn default() -> Self {
             Self {
@@ -350,6 +407,11 @@ pub mod propchain_identity {
                 authorized_verifiers: Mapping::default(),
                 version: 0,
                 privacy_nonces: Mapping::default(),
+                audit_trail: Mapping::default(),
+                audit_count: 0,
+                account_audit_index: Mapping::default(),
+                account_audit_count: Mapping::default(),
+                revocations: Mapping::default(),
             }
         }
     }
@@ -378,6 +440,11 @@ pub mod propchain_identity {
                 authorized_verifiers: Mapping::default(),
                 version: 1,
                 privacy_nonces: Mapping::default(),
+                audit_trail: Mapping::default(),
+                audit_count: 0,
+                account_audit_index: Mapping::default(),
+                account_audit_count: Mapping::default(),
+                revocations: Mapping::default(),
             }
         }
 
@@ -466,6 +533,14 @@ pub mod propchain_identity {
                 timestamp,
             });
 
+            // Record audit entry
+            self.add_audit_entry(
+                caller,
+                caller,
+                "identity_created".into(),
+                "Identity created".into(),
+            );
+
             Ok(())
         }
 
@@ -517,6 +592,14 @@ pub mod propchain_identity {
                 verified_by: caller,
                 timestamp,
             });
+
+            // Record audit entry
+            self.add_audit_entry(
+                target_account,
+                caller,
+                "identity_verified".into(),
+                "Identity verification level updated".into(),
+            );
 
             Ok(())
         }
@@ -998,6 +1081,141 @@ pub mod propchain_identity {
             }
         }
 
+        /// Revoke a compromised identity (admin or authorized verifier only)
+        #[ink(message)]
+        pub fn revoke_identity(
+            &mut self,
+            target_account: AccountId,
+            reason: String,
+        ) -> Result<(), IdentityError> {
+            let caller = self.env().caller();
+            let timestamp = self.env().block_timestamp();
+
+            if !self.is_authorized_verifier(caller) {
+                return Err(IdentityError::Unauthorized);
+            }
+
+            // Identity must exist
+            let mut identity = self
+                .identities
+                .get(&target_account)
+                .ok_or(IdentityError::IdentityNotFound)?;
+
+            // Mark identity as revoked (set verification to None and is_verified false)
+            identity.is_verified = false;
+            identity.verification_level = VerificationLevel::None;
+            identity.trust_score = 0;
+            identity.last_activity = timestamp;
+            self.identities.insert(&target_account, &identity);
+
+            // Store revocation record
+            let record = RevocationRecord {
+                account: target_account,
+                revoked_by: caller,
+                reason: reason.clone(),
+                revoked_at: timestamp,
+            };
+            self.revocations.insert(&target_account, &record);
+
+            // Add audit entry
+            self.add_audit_entry(
+                target_account,
+                caller,
+                "identity_revoked".into(),
+                reason.clone(),
+            );
+
+            self.env().emit_event(IdentityRevoked {
+                account: target_account,
+                revoked_by: caller,
+                reason,
+                timestamp,
+            });
+
+            Ok(())
+        }
+
+        /// Check if an identity has been revoked
+        #[ink(message)]
+        pub fn is_revoked(&self, account: AccountId) -> bool {
+            self.revocations.contains(&account)
+        }
+
+        /// Get the revocation record for an account
+        #[ink(message)]
+        pub fn get_revocation(&self, account: AccountId) -> Option<RevocationRecord> {
+            self.revocations.get(&account)
+        }
+
+        /// Get a specific audit entry by id
+        #[ink(message)]
+        pub fn get_audit_entry(&self, entry_id: u64) -> Option<AuditEntry> {
+            self.audit_trail.get(&entry_id)
+        }
+
+        /// Get the total number of audit entries
+        #[ink(message)]
+        pub fn get_audit_count(&self) -> u64 {
+            self.audit_count
+        }
+
+        /// Get audit entries for a specific account (paginated)
+        #[ink(message)]
+        pub fn get_account_audit_entries(
+            &self,
+            account: AccountId,
+            offset: u64,
+            limit: u64,
+        ) -> Vec<AuditEntry> {
+            let count = self.account_audit_count.get(&account).unwrap_or(0);
+            let mut entries = Vec::new();
+            let end = (offset + limit).min(count);
+            for i in offset..end {
+                if let Some(entry_id) = self.account_audit_index.get(&(account, i)) {
+                    if let Some(entry) = self.audit_trail.get(&entry_id) {
+                        entries.push(entry);
+                    }
+                }
+            }
+            entries
+        }
+
+        /// Internal helper: record an audit entry
+        fn add_audit_entry(
+            &mut self,
+            account: AccountId,
+            performed_by: AccountId,
+            action: String,
+            details: String,
+        ) {
+            let timestamp = self.env().block_timestamp();
+            self.audit_count += 1;
+            let entry_id = self.audit_count;
+
+            let entry = AuditEntry {
+                entry_id,
+                account,
+                action: action.clone(),
+                performed_by,
+                timestamp,
+                details,
+            };
+
+            self.audit_trail.insert(&entry_id, &entry);
+
+            // Update per-account index
+            let idx = self.account_audit_count.get(&account).unwrap_or(0);
+            self.account_audit_index.insert(&(account, idx), &entry_id);
+            self.account_audit_count.insert(&account, &(idx + 1));
+
+            self.env().emit_event(AuditEntryAdded {
+                account,
+                entry_id,
+                action,
+                timestamp,
+            });
+        }
+
         /// Admin methods
         #[ink(message)]
         pub fn add_authorized_verifier(
@@ -1037,6 +1255,121 @@ pub mod propchain_identity {
         #[ink(message)]
         pub fn get_supported_chains(&self) -> Vec<ChainId> {
             self.supported_chains.clone()
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use ink::env::test;
+
+        fn default_registry() -> IdentityRegistry {
+            test::set_caller::<ink::env::DefaultEnvironment>(
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>().alice,
+            );
+            IdentityRegistry::new()
+        }
+
+        fn make_privacy() -> PrivacySettings {
+            PrivacySettings {
+                public_reputation: true,
+                public_verification: true,
+                data_sharing_consent: true,
+                zero_knowledge_proof: false,
+                selective_disclosure: Vec::new(),
+            }
+        }
+
+        #[ink::test]
+        fn test_audit_trail_on_create() {
+            let mut reg = default_registry();
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            assert_eq!(reg.get_audit_count(), 0);
+            reg.create_identity(
+                "did:test:audit1".into(),
+                vec![1u8; 32],
+                "Ed25519".into(),
+                None,
+                make_privacy(),
+            )
+            .unwrap();
+            assert_eq!(reg.get_audit_count(), 1);
+            let entry = reg.get_audit_entry(1).unwrap();
+            assert_eq!(entry.action, "identity_created");
+            assert_eq!(entry.account, accounts.alice);
+        }
+
+        #[ink::test]
+        fn test_audit_trail_on_verify() {
+            let mut reg = default_registry();
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            reg.create_identity(
+                "did:test:audit2".into(),
+                vec![1u8; 32],
+                "Ed25519".into(),
+                None,
+                make_privacy(),
+            )
+            .unwrap();
+            reg.add_authorized_verifier(accounts.alice).unwrap();
+            reg.verify_identity(accounts.alice, VerificationLevel::Basic, None)
+                .unwrap();
+            assert_eq!(reg.get_audit_count(), 2);
+            let entries = reg.get_account_audit_entries(accounts.alice, 0, 10);
+            assert_eq!(entries.len(), 2);
+            assert_eq!(entries[1].action, "identity_verified");
+        }
+
+        #[ink::test]
+        fn test_revoke_identity() {
+            let mut reg = default_registry();
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            // Create identity as bob
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+            reg.create_identity(
+                "did:test:revoke1".into(),
+                vec![1u8; 32],
+                "Ed25519".into(),
+                None,
+                make_privacy(),
+            )
+            .unwrap();
+            // Admin revokes
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.alice);
+            assert_eq!(
+                reg.revoke_identity(accounts.bob, "Compromised".into()),
+                Ok(())
+            );
+            assert!(reg.is_revoked(accounts.bob));
+            let record = reg.get_revocation(accounts.bob).unwrap();
+            assert_eq!(record.reason, "Compromised");
+            assert_eq!(record.revoked_by, accounts.alice);
+            let identity = reg.get_identity(accounts.bob).unwrap();
+            assert!(!identity.is_verified);
+            assert_eq!(identity.trust_score, 0);
+        }
+
+        #[ink::test]
+        fn test_revoke_unauthorized() {
+            let mut reg = default_registry();
+            let accounts =
+                ink::env::test::default_accounts::<ink::env::DefaultEnvironment>();
+            reg.create_identity(
+                "did:test:revoke2".into(),
+                vec![1u8; 32],
+                "Ed25519".into(),
+                None,
+                make_privacy(),
+            )
+            .unwrap();
+            ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.charlie);
+            assert_eq!(
+                reg.revoke_identity(accounts.alice, "Unauthorized".into()),
+                Err(IdentityError::Unauthorized)
+            );
         }
     }
 }

--- a/contracts/identity/tests/identity_tests.rs
+++ b/contracts/identity/tests/identity_tests.rs
@@ -679,8 +679,7 @@ fn test_identity_audit_trail() {
     assert_eq!(identity_registry.get_audit_count(), 2);
 
     // Get account-specific audit entries
-    let entries =
-        identity_registry.get_account_audit_entries(accounts.alice, 0, 10);
+    let entries = identity_registry.get_account_audit_entries(accounts.alice, 0, 10);
     assert_eq!(entries.len(), 2);
     assert_eq!(entries[0].action, "identity_created");
     assert_eq!(entries[1].action, "identity_verified");

--- a/contracts/identity/tests/identity_tests.rs
+++ b/contracts/identity/tests/identity_tests.rs
@@ -631,3 +631,129 @@ fn test_admin_functions() {
     let supported_chains = identity_registry.get_supported_chains();
     assert!(supported_chains.contains(&999));
 }
+
+#[ink::test]
+fn test_identity_audit_trail() {
+    let accounts: DefaultAccounts<ink::env::DefaultEnvironment> = default_accounts();
+    let mut identity_registry = IdentityRegistry::new();
+
+    let did = "did:example:audit123".to_string();
+    let public_key = vec![1u8; 32];
+    let verification_method = "Ed25519VerificationKey2018".to_string();
+    let privacy_settings = PrivacySettings {
+        public_reputation: true,
+        public_verification: true,
+        data_sharing_consent: true,
+        zero_knowledge_proof: false,
+        selective_disclosure: vec![],
+    };
+
+    // Create identity — should add an audit entry
+    assert_eq!(
+        identity_registry.create_identity(
+            did,
+            public_key,
+            verification_method,
+            None,
+            privacy_settings
+        ),
+        Ok(())
+    );
+
+    // Audit count should be 1
+    assert_eq!(identity_registry.get_audit_count(), 1);
+
+    // Retrieve the audit entry
+    let entry = identity_registry.get_audit_entry(1).unwrap();
+    assert_eq!(entry.account, accounts.alice);
+    assert_eq!(entry.action, "identity_created");
+
+    // Verify identity — should add another audit entry
+    identity_registry
+        .add_authorized_verifier(accounts.alice)
+        .unwrap();
+    identity_registry
+        .verify_identity(accounts.alice, VerificationLevel::Standard, Some(365))
+        .unwrap();
+
+    assert_eq!(identity_registry.get_audit_count(), 2);
+
+    // Get account-specific audit entries
+    let entries =
+        identity_registry.get_account_audit_entries(accounts.alice, 0, 10);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].action, "identity_created");
+    assert_eq!(entries[1].action, "identity_verified");
+}
+
+#[ink::test]
+fn test_identity_revocation() {
+    let accounts: DefaultAccounts<ink::env::DefaultEnvironment> = default_accounts();
+    let mut identity_registry = IdentityRegistry::new();
+
+    // Create identity for bob
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+    let did = "did:example:revoke123".to_string();
+    let public_key = vec![1u8; 32];
+    let verification_method = "Ed25519VerificationKey2018".to_string();
+    let privacy_settings = PrivacySettings {
+        public_reputation: true,
+        public_verification: true,
+        data_sharing_consent: true,
+        zero_knowledge_proof: false,
+        selective_disclosure: vec![],
+    };
+    identity_registry
+        .create_identity(did, public_key, verification_method, None, privacy_settings)
+        .unwrap();
+
+    // Admin revokes the identity
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.alice);
+    assert_eq!(
+        identity_registry.revoke_identity(accounts.bob, "Compromised key".into()),
+        Ok(())
+    );
+
+    // Identity should be marked as revoked
+    assert!(identity_registry.is_revoked(accounts.bob));
+
+    // Revocation record should exist
+    let record = identity_registry.get_revocation(accounts.bob).unwrap();
+    assert_eq!(record.account, accounts.bob);
+    assert_eq!(record.revoked_by, accounts.alice);
+    assert_eq!(record.reason, "Compromised key");
+
+    // Identity trust score should be 0 and is_verified false
+    let identity = identity_registry.get_identity(accounts.bob).unwrap();
+    assert!(!identity.is_verified);
+    assert_eq!(identity.trust_score, 0);
+    assert_eq!(identity.verification_level, VerificationLevel::None);
+}
+
+#[ink::test]
+fn test_revocation_unauthorized() {
+    let accounts: DefaultAccounts<ink::env::DefaultEnvironment> = default_accounts();
+    let mut identity_registry = IdentityRegistry::new();
+
+    // Create identity for alice
+    let did = "did:example:revoke456".to_string();
+    let public_key = vec![1u8; 32];
+    let verification_method = "Ed25519VerificationKey2018".to_string();
+    let privacy_settings = PrivacySettings {
+        public_reputation: true,
+        public_verification: true,
+        data_sharing_consent: true,
+        zero_knowledge_proof: false,
+        selective_disclosure: vec![],
+    };
+    identity_registry
+        .create_identity(did, public_key, verification_method, None, privacy_settings)
+        .unwrap();
+
+    // Non-admin (charlie) cannot revoke
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.charlie);
+    assert_eq!(
+        identity_registry.revoke_identity(accounts.alice, "Unauthorized attempt".into()),
+        Err(IdentityError::Unauthorized)
+    );
+}


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to Xhristin3 in a single PR.

Closes #287
Closes #288
Closes #289
Closes #290

---

### #287 — Identity: Add identity audit trail

- Added `AuditEntry` struct (entry_id, account, action, performed_by, timestamp, details)
- New storage: `audit_trail`, `account_audit_index`, `account_audit_count`
- Public methods: `get_audit_entry`, `get_audit_count`, `get_account_audit_entries`
- Internal `add_audit_entry` helper called automatically on `create_identity` and `verify_identity`
- Emits `AuditEntryAdded` event on each audit record

### #288 — Identity: Implement identity revocation

- Added `RevocationRecord` struct (account, revoked_by, reason, revoked_at)
- New storage: `revocations` mapping
- New methods: `revoke_identity` (admin/verifier only), `is_revoked`, `get_revocation`
- Revocation resets `trust_score` to 0, clears `is_verified` and `verification_level`
- Emits `IdentityRevoked` event; adds `IdentityRevoked` error variant

### #289 — Crowdfunding: Add milestone-based fund release (oracle-verified)

- Added `oracle_verified: bool` and `oracle_data_hash: Option<[u8; 32]>` to `Milestone`
- New storage: `authorized_oracles` mapping
- New methods: `oracle_verify_milestone` (oracle/admin), `add_oracle` (admin)
- `release_milestone` now requires `oracle_verified == true`, returns `OracleVerificationFailed` otherwise
- Emits `MilestoneOracleVerified` event

### #290 — Crowdfunding: Implement refund policy for failed campaigns

- New storage: `refunds_issued` mapping
- New methods: `fail_campaign` (admin, marks campaign Cancelled), `claim_refund`, `is_refunded`
- Investors can claim full refund when campaign is Cancelled; double-refund protected
- Emits `RefundIssued` event; adds `CampaignNotFailed`, `AlreadyRefunded`, `NoInvestmentFound` errors

---

## Tests

- **Identity**: 4 new inline `#[cfg(test)]` tests covering audit trail creation, audit on verify, revocation, and unauthorized revocation — all pass via `cargo test --lib`
- **Crowdfunding**: 5 new tests (oracle verify, release requires oracle, refund happy path, refund on active campaign fails, double refund fails) + updated milestone workflow test — all 13 tests pass via `cargo test --lib`