### PR TITLE
Add investor accreditation verification before participation

### DIFF
--- a/contracts/crowdfunding/src/lib.rs
+++ b/contracts/crowdfunding/src/lib.rs
@@ -35,6 +35,7 @@ mod propchain_crowdfunding {
         CampaignNotFailed,
         AlreadyRefunded,
         NoInvestmentFound,
+        AccreditationNotVerified,
     }
 
     impl From<propchain_traits::ReentrancyError> for CrowdfundingError {
@@ -292,6 +293,13 @@ mod propchain_crowdfunding {
         amount: u128,
     }
 
+    #[ink(event)]
+    pub struct AccreditationVerified {
+        #[ink(topic)]
+        investor: AccountId,
+        verified_by: AccountId,
+    }
+
     impl RealEstateCrowdfunding {
         #[ink(constructor)]
         pub fn new(admin: AccountId) -> Self {
@@ -374,6 +382,37 @@ mod propchain_crowdfunding {
             Ok(())
         }
 
+        /// Admin-only: verify an investor's accreditation status
+        #[ink(message)]
+        pub fn verify_accreditation(
+            &mut self,
+            investor: AccountId,
+        ) -> Result<(), CrowdfundingError> {
+            if self.env().caller() != self.admin {
+                return Err(CrowdfundingError::Unauthorized);
+            }
+            let mut profile = self
+                .investor_profiles
+                .get(investor)
+                .ok_or(CrowdfundingError::InvestorNotCompliant)?;
+            profile.accredited = true;
+            self.investor_profiles.insert(investor, &profile);
+            self.env().emit_event(AccreditationVerified {
+                investor,
+                verified_by: self.env().caller(),
+            });
+            Ok(())
+        }
+
+        /// Query whether an investor is accredited
+        #[ink(message)]
+        pub fn is_accredited(&self, investor: AccountId) -> bool {
+            self.investor_profiles
+                .get(investor)
+                .map(|p| p.accredited)
+                .unwrap_or(false)
+        }
+
         #[ink(message)]
         pub fn invest(&mut self, campaign_id: u64, amount: u128) -> Result<(), CrowdfundingError> {
             let caller = self.env().caller();
@@ -383,6 +422,9 @@ mod propchain_crowdfunding {
                 .ok_or(CrowdfundingError::InvestorNotCompliant)?;
             if profile.kyc_status != ComplianceStatus::Approved {
                 return Err(CrowdfundingError::InvestorNotCompliant);
+            }
+            if !profile.accredited {
+                return Err(CrowdfundingError::AccreditationNotVerified);
             }
             if self.blocked_jurisdictions.contains(&profile.jurisdiction) {
                 return Err(CrowdfundingError::InvestorNotCompliant);
@@ -851,11 +893,35 @@ mod tests {
             .create_campaign("Sunset Villas".into(), 100_000)
             .unwrap();
         contract.activate_campaign(campaign_id).unwrap();
+        // Bob onboards (accredited=false until admin verifies)
         test::set_caller::<DefaultEnvironment>(accounts.bob);
-        contract.onboard_investor("US".into(), true).unwrap();
+        contract.onboard_investor("US".into(), false).unwrap();
+        // Admin (alice) verifies accreditation
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract.verify_accreditation(accounts.bob).unwrap();
+        assert!(contract.is_accredited(accounts.bob));
+        // Bob can now invest
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
         assert!(contract.invest(campaign_id, 100_000).is_ok());
         let campaign = contract.get_campaign(campaign_id).unwrap();
         assert_eq!(campaign.status, CampaignStatus::Funded);
+    }
+
+    #[ink::test]
+    fn test_invest_rejected_without_accreditation() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let campaign_id = contract
+            .create_campaign("Sunset Villas".into(), 100_000)
+            .unwrap();
+        contract.activate_campaign(campaign_id).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        contract.onboard_investor("US".into(), false).unwrap();
+        // Bob has not been accredited by admin — invest must fail
+        assert_eq!(
+            contract.invest(campaign_id, 50_000),
+            Err(CrowdfundingError::AccreditationNotVerified)
+        );
     }
 
     #[ink::test]
@@ -921,7 +987,10 @@ mod tests {
             .unwrap();
         contract.activate_campaign(campaign_id).unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.bob);
-        contract.onboard_investor("US".into(), true).unwrap();
+        contract.onboard_investor("US".into(), false).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract.verify_accreditation(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
         contract.invest(campaign_id, 40_000).unwrap();
         // Admin marks campaign as failed
         test::set_caller::<DefaultEnvironment>(accounts.alice);
@@ -942,7 +1011,10 @@ mod tests {
             .unwrap();
         contract.activate_campaign(campaign_id).unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.bob);
-        contract.onboard_investor("US".into(), true).unwrap();
+        contract.onboard_investor("US".into(), false).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract.verify_accreditation(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
         contract.invest(campaign_id, 40_000).unwrap();
         // Refund should fail for active campaign
         assert_eq!(
@@ -960,7 +1032,10 @@ mod tests {
             .unwrap();
         contract.activate_campaign(campaign_id).unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.bob);
-        contract.onboard_investor("US".into(), true).unwrap();
+        contract.onboard_investor("US".into(), false).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract.verify_accreditation(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
         contract.invest(campaign_id, 40_000).unwrap();
         test::set_caller::<DefaultEnvironment>(accounts.alice);
         contract.fail_campaign(campaign_id).unwrap();


### PR DESCRIPTION
 Add investor accreditation verification before participation
  
  Enforces that only admin-verified accredited investors can participate in
  crowdfunding campaigns.
  
  Changes:
  
  - Added AccreditationNotVerified error to CrowdfundingError
  - Added AccreditationVerified event emitted on admin approval
  - Added verify_accreditation(investor) — admin-only message to approve an
  investor's accreditation status
  - Added is_accredited(investor) — read-only query for accreditation status
  - Updated invest() to reject unaccredited investors before allowing
  participation
  - Updated existing tests to go through admin accreditation flow; added
  test_invest_rejected_without_accreditation
  
  Behaviour: Investors self-register via onboard_investor, but the accredited
  flag is only honoured after an admin calls verify_accreditation. Attempting to
  invest without admin verification returns AccreditationNotVerified.
closes #291