### PR TITLE
feat(contract): implement reward tiers for crowdfunding

### DIFF
--- a/contracts/campaign/reward_tiers.rs
+++ b/contracts/campaign/reward_tiers.rs
@@ -1,0 +1,137 @@
+#![no_std]
+
+use soroban_sdk::{
+    contract, contractimpl, contracttype, Env, Address, String, Vec,
+};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct RewardTier {
+    pub id: u32,
+    pub title: String,
+    pub description: String,
+    pub amount: i128,
+    pub max_backers: u32, // 0 = unlimited
+    pub claimed: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    CampaignCreator(u64),
+    RewardTiers(u64),
+}
+
+#[contract]
+pub struct CampaignContract;
+
+#[contractimpl]
+impl CampaignContract {
+
+    // 🔹 Set Campaign Creator (setup)
+    pub fn set_campaign_creator(
+        env: Env,
+        campaign_id: u64,
+        creator: Address,
+    ) {
+        creator.require_auth();
+
+        env.storage()
+            .instance()
+            .set(&DataKey::CampaignCreator(campaign_id), &creator);
+    }
+
+    // 🔹 Add Reward Tier
+    pub fn add_reward_tier(
+        env: Env,
+        campaign_id: u64,
+        creator: Address,
+        tier: RewardTier,
+    ) {
+        creator.require_auth();
+
+        let stored_creator: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::CampaignCreator(campaign_id))
+            .expect("Campaign not found");
+
+        if stored_creator != creator {
+            panic!("Not campaign owner");
+        }
+
+        let mut tiers: Vec<RewardTier> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RewardTiers(campaign_id))
+            .unwrap_or(Vec::new(&env));
+
+        tiers.push_back(tier);
+
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardTiers(campaign_id), &tiers);
+
+        env.events().publish(
+            ("reward_tier_added", campaign_id),
+            "tier_added",
+        );
+    }
+
+    // 🔹 Get Reward Tiers
+    pub fn get_reward_tiers(
+        env: Env,
+        campaign_id: u64,
+    ) -> Vec<RewardTier> {
+        env.storage()
+            .instance()
+            .get(&DataKey::RewardTiers(campaign_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    // 🔹 Claim Reward Tier
+    pub fn claim_reward_tier(
+        env: Env,
+        campaign_id: u64,
+        tier_id: u32,
+        backer: Address,
+    ) {
+        backer.require_auth();
+
+        let mut tiers: Vec<RewardTier> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RewardTiers(campaign_id))
+            .expect("No reward tiers");
+
+        let mut found = false;
+
+        for i in 0..tiers.len() {
+            let mut tier = tiers.get(i).unwrap();
+
+            if tier.id == tier_id {
+                if tier.max_backers != 0 && tier.claimed >= tier.max_backers {
+                    panic!("Tier sold out");
+                }
+
+                tier.claimed += 1;
+                tiers.set(i, tier);
+                found = true;
+                break;
+            }
+        }
+
+        if !found {
+            panic!("Tier not found");
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::RewardTiers(campaign_id), &tiers);
+
+        env.events().publish(
+            ("reward_claimed", campaign_id),
+            tier_id,
+        );
+    }
+}

--- a/contracts/campaign/risk_disclosure.rs
+++ b/contracts/campaign/risk_disclosure.rs
@@ -1,0 +1,91 @@
+// Soroban Smart Contract Feature: Require Risk Disclosure for All Campaigns
+// This module enforces that every campaign must include a risk disclosure
+// before it can be considered valid or active.
+
+use soroban_sdk::{contract, contractimpl, contracttype, Env, String, Address};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DataKey {
+    CampaignCreator(u64),
+    RiskDisclosure(u64),
+}
+
+#[contract]
+pub struct CampaignContract;
+
+#[contractimpl]
+impl CampaignContract {
+
+    // 🔹 Set Risk Disclosure (Required before campaign activation)
+    pub fn set_risk_disclosure(
+        env: Env,
+        campaign_id: u64,
+        creator: Address,
+        disclosure: String,
+    ) {
+        // Ensure creator signs transaction
+        creator.require_auth();
+
+        // Verify campaign exists and creator owns it
+        let stored_creator: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::CampaignCreator(campaign_id))
+            .expect("Campaign not found");
+
+        if stored_creator != creator {
+            panic!("Unauthorized: Not campaign owner");
+        }
+
+        // Basic validation
+        if disclosure.len() < 20 {
+            panic!("Risk disclosure too short");
+        }
+
+        // Store disclosure
+        env.storage()
+            .instance()
+            .set(&DataKey::RiskDisclosure(campaign_id), &disclosure);
+
+        // Emit event
+        env.events().publish(
+            ("risk_disclosure_set", campaign_id),
+            disclosure.clone(),
+        );
+    }
+
+    // 🔹 Get Risk Disclosure
+    pub fn get_risk_disclosure(env: Env, campaign_id: u64) -> String {
+        env.storage()
+            .instance()
+            .get(&DataKey::RiskDisclosure(campaign_id))
+            .expect("Risk disclosure not set")
+    }
+
+    // 🔹 Validate Campaign Before Actions (e.g., funding)
+    pub fn validate_campaign(env: Env, campaign_id: u64) {
+        let exists: Option<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RiskDisclosure(campaign_id));
+
+        if exists.is_none() {
+            panic!("Campaign missing required risk disclosure");
+        }
+    }
+
+    // 🔹 Example: Funding function with enforcement
+    pub fn fund_campaign(env: Env, campaign_id: u64, backer: Address) {
+        backer.require_auth();
+
+        // Enforce disclosure before funding
+        Self::validate_campaign(env.clone(), campaign_id);
+
+        // Continue funding logic (not implemented here)
+        env.events().publish(
+            ("campaign_funded", campaign_id),
+            backer,
+        );
+    }
+}

--- a/contracts/crowdfunding/README.md
+++ b/contracts/crowdfunding/README.md
@@ -67,6 +67,14 @@ contract.onboard_investor("US".into(), true)?;
 contract.invest(campaign_id, 250_000)?;
 ```
 
+### Campaign Updates
+
+```rust
+let update_id = contract.post_update(campaign_id, "Project milestone reached".into())?;
+let update_count = contract.get_update_count(campaign_id);
+let update = contract.get_campaign_update(campaign_id, update_id).unwrap();
+```
+
 ### Milestone Management
 
 ```rust

--- a/contracts/crowdfunding/src/lib.rs
+++ b/contracts/crowdfunding/src/lib.rs
@@ -199,6 +199,18 @@ mod propchain_crowdfunding {
         Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
     )]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct CampaignUpdate {
+        pub update_id: u64,
+        pub campaign_id: u64,
+        pub creator: AccountId,
+        pub content: String,
+        pub timestamp: u64,
+    }
+
+    #[derive(
+        Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub struct RiskProfile {
         pub campaign_id: u64,
         pub ltv_ratio: u32,
@@ -230,6 +242,8 @@ mod propchain_crowdfunding {
         authorized_oracles: Mapping<AccountId, bool>,
         /// Tracks whether an investor has been refunded for a campaign
         refunds_issued: Mapping<(u64, AccountId), bool>,
+        campaign_update_counts: Mapping<u64, u64>,
+        campaign_updates: Mapping<(u64, u64), CampaignUpdate>,
     }
 
     #[ink(event)]
@@ -290,6 +304,17 @@ mod propchain_crowdfunding {
         #[ink(topic)]
         investor: AccountId,
         amount: u128,
+    }
+
+    #[ink(event)]
+    pub struct CampaignUpdatePosted {
+        #[ink(topic)]
+        campaign_id: u64,
+        #[ink(topic)]
+        update_id: u64,
+        #[ink(topic)]
+        creator: AccountId,
+        timestamp: u64,
     }
 
     impl RealEstateCrowdfunding {
@@ -443,6 +468,55 @@ mod propchain_crowdfunding {
             };
             self.milestones.insert(self.milestone_count, &milestone);
             Ok(self.milestone_count)
+        }
+
+        #[ink(message)]
+        pub fn post_update(
+            &mut self,
+            campaign_id: u64,
+            content: String,
+        ) -> Result<u64, CrowdfundingError> {
+            let mut campaign = self
+                .campaigns
+                .get(campaign_id)
+                .ok_or(CrowdfundingError::CampaignNotFound)?;
+            if self.env().caller() != campaign.creator {
+                return Err(CrowdfundingError::Unauthorized);
+            }
+            if campaign.status == CampaignStatus::Cancelled {
+                return Err(CrowdfundingError::CampaignNotActive);
+            }
+            let update_count = self.campaign_update_counts.get(campaign_id).unwrap_or(0) + 1;
+            self.campaign_update_counts.insert(campaign_id, &update_count);
+            let update = CampaignUpdate {
+                update_id: update_count,
+                campaign_id,
+                creator: self.env().caller(),
+                content,
+                timestamp: self.env().block_timestamp(),
+            };
+            self.campaign_updates.insert((campaign_id, update_count), &update);
+            self.env().emit_event(CampaignUpdatePosted {
+                campaign_id,
+                update_id: update_count,
+                creator: self.env().caller(),
+                timestamp: update.timestamp,
+            });
+            Ok(update_count)
+        }
+
+        #[ink(message)]
+        pub fn get_update_count(&self, campaign_id: u64) -> u64 {
+            self.campaign_update_counts.get(campaign_id).unwrap_or(0)
+        }
+
+        #[ink(message)]
+        pub fn get_campaign_update(
+            &self,
+            campaign_id: u64,
+            update_id: u64,
+        ) -> Option<CampaignUpdate> {
+            self.campaign_updates.get((campaign_id, update_id))
         }
 
         #[ink(message)]
@@ -856,6 +930,32 @@ mod tests {
         assert!(contract.invest(campaign_id, 100_000).is_ok());
         let campaign = contract.get_campaign(campaign_id).unwrap();
         assert_eq!(campaign.status, CampaignStatus::Funded);
+    }
+
+    #[ink::test]
+    fn test_campaign_creator_can_post_update() {
+        let mut contract = setup();
+        let campaign_id = contract.create_campaign("Sunset Villas".into(), 100_000).unwrap();
+        let update_id = contract
+            .post_update(campaign_id, "Campaign launched".into())
+            .unwrap();
+        assert_eq!(update_id, 1);
+        assert_eq!(contract.get_update_count(campaign_id), 1);
+        let update = contract.get_campaign_update(campaign_id, update_id).unwrap();
+        assert_eq!(update.creator, test::default_accounts::<DefaultEnvironment>().alice);
+        assert_eq!(update.content, "Campaign launched");
+    }
+
+    #[ink::test]
+    fn test_non_creator_cannot_post_update() {
+        let mut contract = setup();
+        let campaign_id = contract.create_campaign("Sunset Villas".into(), 100_000).unwrap();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        assert_eq!(
+            contract.post_update(campaign_id, "Update from wrong account".into()),
+            Err(CrowdfundingError::Unauthorized)
+        );
     }
 
     #[ink::test]


### PR DESCRIPTION
feat(contract): implement reward tiers for crowdfunding

- added reward tier struct and storage
- allow creators to define reward tiers per campaign
- enable backers to claim tiers with limit enforcement
- emit events for tier creation and claims

closes #296 