### PR TITLE
Add identity portability support to propchain-identity

### DIFF
--- a/contracts/identity/lib.rs
+++ b/contracts/identity/lib.rs
@@ -374,6 +374,15 @@ pub mod propchain_identity {
     }
 
     #[ink(event)]
+    pub struct IdentityPorted {
+        #[ink(topic)]
+        old_account: AccountId,
+        #[ink(topic)]
+        new_account: AccountId,
+        timestamp: u64,
+    }
+
+    #[ink(event)]
     pub struct IdentityRevoked {
         #[ink(topic)]
         account: AccountId,
@@ -927,6 +936,61 @@ pub mod propchain_identity {
                 new_account,
                 timestamp: _timestamp,
             });
+
+            Ok(())
+        }
+
+        /// Port an existing identity to a new account
+        #[ink(message)]
+        pub fn port_identity(&mut self, new_account: AccountId) -> Result<(), IdentityError> {
+            let caller = self.env().caller();
+            let timestamp = self.env().block_timestamp();
+
+            if caller == new_account {
+                return Err(IdentityError::IdentityAlreadyExists);
+            }
+
+            // Source identity must exist and must not be revoked
+            let mut identity = self
+                .identities
+                .get(&caller)
+                .ok_or(IdentityError::IdentityNotFound)?;
+
+            if self.revocations.contains(&caller) {
+                return Err(IdentityError::IdentityRevoked);
+            }
+
+            if self.identities.contains(&new_account) {
+                return Err(IdentityError::IdentityAlreadyExists);
+            }
+
+            identity.account_id = new_account;
+            identity.last_activity = timestamp;
+            identity.did_document.updated_at = timestamp;
+            identity.did_document.version = identity.did_document.version.saturating_add(1);
+
+            self.identities.remove(&caller);
+            self.identities.insert(&new_account, &identity);
+            self.did_to_account
+                .insert(&identity.did_document.did, &new_account);
+
+            if let Some(metrics) = self.reputation_metrics.get(&caller) {
+                self.reputation_metrics.remove(&caller);
+                self.reputation_metrics.insert(&new_account, &metrics);
+            }
+
+            self.env().emit_event(IdentityPorted {
+                old_account: caller,
+                new_account,
+                timestamp,
+            });
+
+            self.add_audit_entry(
+                new_account,
+                caller,
+                "identity_ported".into(),
+                "Identity ported to new account".into(),
+            );
 
             Ok(())
         }

--- a/contracts/identity/tests/identity_tests.rs
+++ b/contracts/identity/tests/identity_tests.rs
@@ -756,3 +756,96 @@ fn test_revocation_unauthorized() {
         Err(IdentityError::Unauthorized)
     );
 }
+
+#[ink::test]
+fn test_port_identity_success() {
+    let accounts: DefaultAccounts<ink::env::DefaultEnvironment> = default_accounts();
+    let mut identity_registry = IdentityRegistry::new();
+
+    // Create identity for bob
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+    let did = "did:example:port123".to_string();
+    let public_key = vec![1u8; 32];
+    let verification_method = "Ed25519VerificationKey2018".to_string();
+    let privacy_settings = PrivacySettings {
+        public_reputation: true,
+        public_verification: true,
+        data_sharing_consent: true,
+        zero_knowledge_proof: false,
+        selective_disclosure: vec![],
+    };
+
+    assert_eq!(
+        identity_registry.create_identity(
+            did.clone(),
+            public_key.clone(),
+            verification_method.clone(),
+            None,
+            privacy_settings,
+        ),
+        Ok(())
+    );
+
+    let new_account = AccountId::from([2u8; 32]);
+
+    // Port identity from bob to new_account
+    assert_eq!(identity_registry.port_identity(new_account), Ok(()));
+
+    // Old account should no longer have an identity
+    assert!(identity_registry.get_identity(accounts.bob).is_none());
+
+    // New account should have the same DID and reputation
+    let ported_identity = identity_registry.get_identity(new_account).unwrap();
+    assert_eq!(ported_identity.did_document.did, did);
+    assert_eq!(ported_identity.reputation_score, 500);
+    assert_eq!(ported_identity.account_id, new_account);
+}
+
+#[ink::test]
+fn test_port_identity_target_already_exists() {
+    let accounts: DefaultAccounts<ink::env::DefaultEnvironment> = default_accounts();
+    let mut identity_registry = IdentityRegistry::new();
+
+    // Create identity for alice and bob
+    let did_alice = "did:example:alice123".to_string();
+    let did_bob = "did:example:bob123".to_string();
+    let public_key = vec![1u8; 32];
+    let verification_method = "Ed25519VerificationKey2018".to_string();
+    let privacy_settings = PrivacySettings {
+        public_reputation: true,
+        public_verification: true,
+        data_sharing_consent: true,
+        zero_knowledge_proof: false,
+        selective_disclosure: vec![],
+    };
+
+    assert_eq!(
+        identity_registry.create_identity(
+            did_alice,
+            public_key.clone(),
+            verification_method.clone(),
+            None,
+            privacy_settings.clone(),
+        ),
+        Ok(())
+    );
+
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.bob);
+    assert_eq!(
+        identity_registry.create_identity(
+            did_bob,
+            public_key,
+            verification_method,
+            None,
+            privacy_settings,
+        ),
+        Ok(())
+    );
+
+    // Set caller back to alice and attempt to port to bob
+    ink::env::test::set_caller::<ink::env::DefaultEnvironment>(accounts.alice);
+    assert_eq!(
+        identity_registry.port_identity(accounts.bob),
+        Err(IdentityError::IdentityAlreadyExists)
+    );
+}


### PR DESCRIPTION
Close #286 

## PR Description

### Summary
Implemented identity portability support in the identity module to allow users to port their existing identity from one account to another while preserving DID, reputation, and audit history.

### Changes
- Added `IdentityPorted` event to lib.rs
- Added `port_identity(new_account: AccountId)` message to `IdentityRegistry`
- Updated portability logic to:
  - validate source identity exists
  - prevent porting revoked or already-registered target accounts
  - preserve DID and reputation metrics
  - update identity mappings and audit trail
- Added focused tests in identity_tests.rs covering:
  - successful identity port
  - port failure when target account already exists

### Testing
- No compile or diagnostics errors found in modified files
- Recommended command for local verification:
  - `cargo test -p propchain-identity -- --nocapture`


