### PR TITLE
feat: implement WebSocket streaming for contract events

### DIFF
--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -11,7 +11,7 @@ ingest = []
 
 [dependencies]
 anyhow = "1.0"
-axum = { version = "0.7", features = ["macros", "json"] }
+axum = { version = "0.7", features = ["macros", "json", "ws"] }
 axum-prometheus = "0.6"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -4,6 +4,8 @@ mod graphql;
 #[cfg(feature = "ingest")]
 mod ingest;
 mod openapi;
+mod poller;
+mod ws;
 
 use crate::api::{health, list_events, ApiState};
 use crate::openapi::ApiDoc;
@@ -53,6 +55,18 @@ async fn main() -> anyhow::Result<()> {
 
     let db = Arc::new(db);
 
+    // WebSocket broadcast channel for streaming events
+    let ws_state = ws::WsState::new();
+
+    // Spawn DB poller — publishes new events to WebSocket subscribers
+    {
+        let db_clone = db.clone();
+        let ws_clone = ws_state.clone();
+        tokio::spawn(async move {
+            poller::run_poller(db_clone, ws_clone).await;
+        });
+    }
+
     // Start ingestor in background
     #[cfg(feature = "ingest")]
     {
@@ -98,9 +112,14 @@ async fn main() -> anyhow::Result<()> {
         )
         .with_state(schema);
 
+    let ws_router = Router::new()
+        .route("/ws/events", get(ws::ws_handler))
+        .with_state(ws_state);
+
     let app = Router::new()
         .merge(rest_router)
         .merge(graphql_router)
+        .merge(ws_router)
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .layer(prometheus_layer)
         .layer(cors)

--- a/indexer/src/poller.rs
+++ b/indexer/src/poller.rs
@@ -1,0 +1,112 @@
+//! Lightweight DB poller that publishes newly inserted events to the
+//! WebSocket broadcast channel.
+//!
+//! This runs as a background task and polls `contract_events` every
+//! `POLL_INTERVAL_MS` milliseconds for rows inserted since the last
+//! seen `inserted_at` timestamp.  It is intentionally simple and does
+//! not require the `subxt` / `ingest` feature to be enabled.
+
+use crate::db::Db;
+use crate::ws::{EventEnvelope, WsState};
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+use tokio::time::{interval, Duration};
+use tracing::{debug, error, info};
+
+/// How often to poll for new events (milliseconds).
+const POLL_INTERVAL_MS: u64 = 500;
+
+/// Run the poller loop indefinitely.
+///
+/// Publishes every new `contract_events` row to `ws_state` so connected
+/// WebSocket clients receive it in near-real-time.
+pub async fn run_poller(db: Arc<Db>, ws_state: WsState) {
+    info!("Event poller started (interval={}ms)", POLL_INTERVAL_MS);
+
+    let mut ticker = interval(Duration::from_millis(POLL_INTERVAL_MS));
+    // Track the high-water mark so we only fetch rows we haven't seen yet.
+    let mut last_seen: DateTime<Utc> = Utc::now();
+
+    loop {
+        ticker.tick().await;
+
+        match fetch_new_events(&db, last_seen).await {
+            Ok(events) => {
+                if events.is_empty() {
+                    continue;
+                }
+                debug!("Poller fetched {} new event(s)", events.len());
+                for event in events {
+                    // Advance the high-water mark.
+                    if event.block_timestamp > last_seen {
+                        last_seen = event.block_timestamp;
+                    }
+                    let envelope = EventEnvelope::from(event);
+                    let receivers = ws_state.publish(envelope);
+                    debug!("Published event to {receivers} WebSocket subscriber(s)");
+                }
+            }
+            Err(e) => {
+                error!("Poller DB query failed: {e}");
+            }
+        }
+    }
+}
+
+async fn fetch_new_events(
+    db: &Db,
+    since: DateTime<Utc>,
+) -> anyhow::Result<Vec<crate::db::IndexedEvent>> {
+    let rows = sqlx::query_as::<
+        _,
+        (
+            uuid::Uuid,
+            i64,
+            String,
+            DateTime<Utc>,
+            String,
+            Option<String>,
+            Option<Vec<String>>,
+            String,
+        ),
+    >(
+        r#"
+        SELECT id, block_number, block_hash, block_timestamp,
+               contract, event_type, topics, payload_hex
+        FROM   contract_events
+        WHERE  inserted_at > $1
+        ORDER  BY inserted_at ASC
+        LIMIT  500
+        "#,
+    )
+    .bind(since)
+    .fetch_all(&db.pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                block_number,
+                block_hash,
+                block_timestamp,
+                contract,
+                event_type,
+                topics,
+                payload_hex,
+            )| {
+                crate::db::IndexedEvent {
+                    id,
+                    block_number,
+                    block_hash,
+                    block_timestamp,
+                    contract,
+                    event_type,
+                    topics,
+                    payload_hex,
+                }
+            },
+        )
+        .collect())
+}

--- a/indexer/src/ws.rs
+++ b/indexer/src/ws.rs
@@ -1,0 +1,250 @@
+//! WebSocket handler for streaming contract events in real-time.
+//!
+//! ## Architecture
+//!
+//! A single `tokio::sync::broadcast` channel acts as the event bus:
+//!
+//! ```text
+//!  Ingestor / DB poller
+//!       │  publishes EventEnvelope
+//!       ▼
+//!  broadcast::Sender<EventEnvelope>   (capacity = 1024)
+//!       │
+//!       ├── WS client 1  (optional filter: contract / event_type)
+//!       ├── WS client 2
+//!       └── WS client N
+//! ```
+//!
+//! ## Client protocol
+//!
+//! After the WebSocket handshake the client may send a JSON filter message:
+//!
+//! ```json
+//! { "contract": "5Grwv...", "event_type": "PropertyRegistered" }
+//! ```
+//!
+//! Both fields are optional. Omitting a field means "match all".
+//! The server then streams matching `EventEnvelope` objects as JSON text frames.
+//! A ping/pong keepalive is sent every 30 seconds.
+
+use crate::db::IndexedEvent;
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::IntoResponse,
+};
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
+
+/// Capacity of the broadcast channel (number of events buffered).
+/// Slow clients that fall behind by more than this will receive a
+/// `lagged` error and be disconnected gracefully.
+const BROADCAST_CAPACITY: usize = 1024;
+
+/// Keepalive interval in seconds.
+const PING_INTERVAL_SECS: u64 = 30;
+
+// ── Shared state ─────────────────────────────────────────────────────────────
+
+/// Cloneable handle passed into Axum router state.
+#[derive(Clone)]
+pub struct WsState {
+    pub tx: Arc<broadcast::Sender<EventEnvelope>>,
+}
+
+impl WsState {
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        Self { tx: Arc::new(tx) }
+    }
+
+    /// Publish an event to all connected WebSocket clients.
+    /// Returns the number of active receivers.
+    pub fn publish(&self, event: EventEnvelope) -> usize {
+        match self.tx.send(event) {
+            Ok(n) => n,
+            // No subscribers — that's fine.
+            Err(_) => 0,
+        }
+    }
+}
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+/// The payload broadcast to every subscriber.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct EventEnvelope {
+    /// Source contract address.
+    pub contract: String,
+    /// Decoded event type name (if available).
+    pub event_type: Option<String>,
+    /// Block number the event was emitted in.
+    pub block_number: i64,
+    /// RFC3339 block timestamp.
+    pub block_timestamp: String,
+    /// Raw payload as hex.
+    pub payload_hex: String,
+    /// Decoded topics (if available).
+    pub topics: Option<Vec<String>>,
+}
+
+impl From<IndexedEvent> for EventEnvelope {
+    fn from(e: IndexedEvent) -> Self {
+        Self {
+            contract: e.contract,
+            event_type: e.event_type,
+            block_number: e.block_number,
+            block_timestamp: e.block_timestamp.to_rfc3339(),
+            payload_hex: e.payload_hex,
+            topics: e.topics,
+        }
+    }
+}
+
+/// Optional filter sent by the client after connecting.
+#[derive(Debug, Deserialize, Default)]
+pub struct ClientFilter {
+    /// Only stream events from this contract address.
+    pub contract: Option<String>,
+    /// Only stream events of this type.
+    pub event_type: Option<String>,
+}
+
+impl ClientFilter {
+    fn matches(&self, env: &EventEnvelope) -> bool {
+        if let Some(ref c) = self.contract {
+            if &env.contract != c {
+                return false;
+            }
+        }
+        if let Some(ref et) = self.event_type {
+            match &env.event_type {
+                Some(actual) if actual == et => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+// ── Axum handler ─────────────────────────────────────────────────────────────
+
+/// Upgrade an HTTP request to a WebSocket connection.
+///
+/// Route: `GET /ws/events`
+///
+/// Query params (optional, can also be sent as a JSON message after connect):
+/// - `contract` — filter by contract address
+/// - `event_type` — filter by event type name
+#[utoipa::path(
+    get,
+    path = "/ws/events",
+    tag = "Events",
+    responses(
+        (status = 101, description = "WebSocket upgrade — streams EventEnvelope JSON frames"),
+    )
+)]
+pub async fn ws_handler(ws: WebSocketUpgrade, State(state): State<WsState>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+async fn handle_socket(socket: WebSocket, state: WsState) {
+    let (mut sender, mut receiver) = socket.split();
+    let mut rx = state.tx.subscribe();
+
+    // Default filter — accept everything until the client sends one.
+    let mut filter = ClientFilter::default();
+
+    info!("WebSocket client connected");
+
+    let mut ping_interval =
+        tokio::time::interval(std::time::Duration::from_secs(PING_INTERVAL_SECS));
+    // Skip the immediate first tick so we don't ping before the client is ready.
+    ping_interval.tick().await;
+
+    loop {
+        tokio::select! {
+            // ── Incoming message from client ──────────────────────────────
+            msg = receiver.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        match serde_json::from_str::<ClientFilter>(&text) {
+                            Ok(f) => {
+                                debug!("Client updated filter: contract={:?} event_type={:?}",
+                                    f.contract, f.event_type);
+                                filter = f;
+                            }
+                            Err(e) => {
+                                warn!("Ignoring unparseable filter message: {e}");
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => {
+                        info!("WebSocket client disconnected");
+                        break;
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        // keepalive acknowledged — nothing to do
+                    }
+                    Some(Err(e)) => {
+                        warn!("WebSocket receive error: {e}");
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+
+            // ── Broadcast event from ingestor ─────────────────────────────
+            result = rx.recv() => {
+                match result {
+                    Ok(envelope) => {
+                        if !filter.matches(&envelope) {
+                            continue;
+                        }
+                        let json = match serde_json::to_string(&envelope) {
+                            Ok(j) => j,
+                            Err(e) => {
+                                warn!("Failed to serialize event: {e}");
+                                continue;
+                            }
+                        };
+                        if sender.send(Message::Text(json)).await.is_err() {
+                            // Client disconnected mid-send.
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("WebSocket client lagged, dropped {n} events");
+                        // Notify the client and continue — don't disconnect.
+                        let notice = serde_json::json!({
+                            "error": "lagged",
+                            "dropped": n
+                        })
+                        .to_string();
+                        if sender.send(Message::Text(notice)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        // Broadcast channel shut down (server stopping).
+                        break;
+                    }
+                }
+            }
+
+            // ── Keepalive ping ────────────────────────────────────────────
+            _ = ping_interval.tick() => {
+                if sender.send(Message::Ping(vec![])).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+
+    info!("WebSocket handler exiting");
+}


### PR DESCRIPTION
# feat: Implement WebSocket connections for streaming contract events

## Summary

Adds real-time WebSocket event streaming to the PropChain indexer. Clients can
connect to a single endpoint and receive a live feed of contract events as they
are written to the database, with optional per-connection filtering by contract
address and event type.

## Motivation

Closes: #169

Previously, the only way to consume contract events was by polling the REST
`GET /events` endpoint. This is inefficient for UIs and off-chain services that
need low-latency updates (e.g. a frontend showing live property transfers or
escrow state changes). WebSocket streaming eliminates the need for polling and
delivers events within ~500ms of them hitting the database.

## Changes

### New: `indexer/src/ws.rs`

Core WebSocket module built on Axum's native WS support and
`tokio::sync::broadcast`.

**Architecture:**

```
  DB poller / ingestor
        │  publishes EventEnvelope
        ▼
  broadcast::Sender<EventEnvelope>   (capacity = 1024)
        │
        ├── WS client 1  (filter: contract=0x..., event_type=PropertyRegistered)
        ├── WS client 2  (no filter — receives everything)
        └── WS client N
```

**Key behaviours:**

- `GET /ws/events` — HTTP → WebSocket upgrade endpoint
- After connecting, clients may send a JSON filter frame at any time:
  ```json
  { "contract": "5GrwvaEF...", "event_type": "PropertyRegistered" }
  ```
  Both fields are optional. Omitting a field means "match all". The filter can
  be updated mid-connection by sending a new message.
- Matching `EventEnvelope` objects are streamed as JSON text frames
- Clients that fall behind the broadcast buffer by more than 1024 events receive
  a lag notification frame instead of being silently disconnected:
  ```json
  { "error": "lagged", "dropped": 42 }
  ```
- 30-second ping/pong keepalive to detect stale connections

**`EventEnvelope` schema:**

| Field | Type | Description |
|---|---|---|
| `contract` | `string` | Source contract address |
| `event_type` | `string \| null` | Decoded event name |
| `block_number` | `integer` | Block the event was emitted in |
| `block_timestamp` | `string` | RFC3339 block timestamp |
| `payload_hex` | `string` | Raw event payload (hex) |
| `topics` | `string[] \| null` | Decoded topics |

---

### New: `indexer/src/poller.rs`

Background task that bridges the database and the broadcast channel.

- Polls `contract_events` every **500ms** for rows with `inserted_at` newer
  than the last seen high-water mark
- Converts each row to an `EventEnvelope` and calls `ws_state.publish()`
- Fetches up to 500 rows per tick to handle bursts
- Operates independently of the disabled `subxt`/`ingest` feature — any write
  to `contract_events` (ingestor, tests, manual inserts) is picked up
  automatically

---

### Modified: `indexer/src/main.rs`

- Registered `mod poller` and `mod ws`
- Instantiated `WsState` (holds the broadcast sender)
- Spawned `poller::run_poller` as a background Tokio task
- Added `GET /ws/events` route via a dedicated `ws_router` merged into the
  main Axum app

---

### Modified: `indexer/Cargo.toml`

- Enabled the `ws` feature on the `axum` dependency:
  ```toml
  axum = { version = "0.7", features = ["macros", "json", "ws"] }
  ```

---