### PR TITLE
feat(fractional): AMM-style dynamic share pricing (#269)

### DIFF
--- a/contracts/fractional/src/lib.rs
+++ b/contracts/fractional/src/lib.rs
@@ -70,6 +70,24 @@ mod fractional {
         pub price_per_share: u128,
     }
 
+    /// AMM liquidity pool for a property token using constant-product (x * y = k).
+    /// `share_reserve` = shares in pool, `value_reserve` = native-token value in pool.
+    #[derive(
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        scale::Encode,
+        scale::Decode,
+        ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct AmmPool {
+        pub share_reserve: u128,
+        pub value_reserve: u128,
+        pub lp_supply: u128,
+    }
+
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub enum FractionalError {
@@ -78,6 +96,11 @@ mod fractional {
         InsufficientPayment,
         Unauthorized,
         ZeroAmount,
+        PoolNotFound,
+        PoolAlreadyExists,
+        SlippageExceeded,
+        InsufficientLiquidity,
+        InsufficientLpShares,
     }
 
     /// Emitted when an owner lists shares for sale
@@ -120,6 +143,39 @@ mod fractional {
         token_id: u64,
     }
 
+    /// Emitted when liquidity is added to an AMM pool
+    #[ink(event)]
+    pub struct LiquidityAdded {
+        #[ink(topic)]
+        provider: AccountId,
+        token_id: u64,
+        shares_added: u128,
+        value_added: u128,
+        lp_minted: u128,
+    }
+
+    /// Emitted when liquidity is removed from an AMM pool
+    #[ink(event)]
+    pub struct LiquidityRemoved {
+        #[ink(topic)]
+        provider: AccountId,
+        token_id: u64,
+        shares_out: u128,
+        value_out: u128,
+        lp_burned: u128,
+    }
+
+    /// Emitted when shares are swapped for value via the AMM
+    #[ink(event)]
+    pub struct SharesSwapped {
+        #[ink(topic)]
+        trader: AccountId,
+        token_id: u64,
+        shares_in: u128,
+        value_out: u128,
+        new_spot_price: u128,
+    }
+
     #[ink(storage)]
     pub struct Fractional {
         last_prices: Mapping<u64, u128>,
@@ -129,6 +185,10 @@ mod fractional {
         listings: Mapping<(AccountId, u64), ShareListing>,
         /// Total shares issued per token_id
         total_shares: Mapping<u64, u128>,
+        /// AMM pools per token_id
+        amm_pools: Mapping<u64, AmmPool>,
+        /// LP token balances per (provider, token_id)
+        lp_balances: Mapping<(AccountId, u64), u128>,
     }
 
     impl Fractional {
@@ -139,6 +199,8 @@ mod fractional {
                 balances: Mapping::default(),
                 listings: Mapping::default(),
                 total_shares: Mapping::default(),
+                amm_pools: Mapping::default(),
+                lp_balances: Mapping::default(),
             }
         }
     }
@@ -380,6 +442,287 @@ mod fractional {
         pub fn get_listing(&self, seller: AccountId, token_id: u64) -> Option<ShareListing> {
             self.listings.get(&(seller, token_id))
         }
+
+        // ── Issue #269: AMM-style dynamic share pricing ──────────────────────
+
+        /// Seed a new constant-product AMM pool for `token_id`.
+        /// The caller contributes `share_amount` shares and attaches native value.
+        /// Caller must already hold `share_amount` shares.
+        #[ink(message, payable)]
+        pub fn add_liquidity(
+            &mut self,
+            token_id: u64,
+            share_amount: u128,
+            min_lp_out: u128,
+        ) -> Result<u128, FractionalError> {
+            if share_amount == 0 {
+                return Err(FractionalError::ZeroAmount);
+            }
+            let caller = self.env().caller();
+            let value_in = self.env().transferred_value();
+            if value_in == 0 {
+                return Err(FractionalError::ZeroAmount);
+            }
+
+            let held = self.balances.get(&(caller, token_id)).unwrap_or(0);
+            if held < share_amount {
+                return Err(FractionalError::InsufficientShares);
+            }
+
+            let lp_minted;
+            let pool = self.amm_pools.get(token_id);
+            let updated = match pool {
+                None => {
+                    // First deposit: LP = sqrt(share_amount * value_in), floored via integer sqrt
+                    lp_minted = Self::isqrt(share_amount.saturating_mul(value_in));
+                    AmmPool {
+                        share_reserve: share_amount,
+                        value_reserve: value_in,
+                        lp_supply: lp_minted,
+                    }
+                }
+                Some(p) => {
+                    // Proportional deposit: LP = min(share/share_reserve, value/value_reserve) * lp_supply
+                    let lp_by_share = share_amount
+                        .saturating_mul(p.lp_supply)
+                        .checked_div(p.share_reserve)
+                        .unwrap_or(0);
+                    let lp_by_value = value_in
+                        .saturating_mul(p.lp_supply)
+                        .checked_div(p.value_reserve)
+                        .unwrap_or(0);
+                    lp_minted = lp_by_share.min(lp_by_value);
+                    AmmPool {
+                        share_reserve: p.share_reserve.saturating_add(share_amount),
+                        value_reserve: p.value_reserve.saturating_add(value_in),
+                        lp_supply: p.lp_supply.saturating_add(lp_minted),
+                    }
+                }
+            };
+
+            if lp_minted < min_lp_out {
+                return Err(FractionalError::SlippageExceeded);
+            }
+
+            // Lock shares in pool (deduct from caller balance)
+            self.balances
+                .insert(&(caller, token_id), &held.saturating_sub(share_amount));
+
+            // Update spot price
+            if updated.share_reserve > 0 {
+                let spot = updated.value_reserve / updated.share_reserve;
+                self.last_prices.insert(token_id, &spot);
+            }
+
+            self.amm_pools.insert(token_id, &updated);
+            let lp_held = self.lp_balances.get(&(caller, token_id)).unwrap_or(0);
+            self.lp_balances
+                .insert(&(caller, token_id), &lp_held.saturating_add(lp_minted));
+
+            self.env().emit_event(LiquidityAdded {
+                provider: caller,
+                token_id,
+                shares_added: share_amount,
+                value_added: value_in,
+                lp_minted,
+            });
+            Ok(lp_minted)
+        }
+
+        /// Burn `lp_amount` LP tokens and withdraw proportional shares + value.
+        #[ink(message)]
+        pub fn remove_liquidity(
+            &mut self,
+            token_id: u64,
+            lp_amount: u128,
+            min_shares_out: u128,
+            min_value_out: u128,
+        ) -> Result<(u128, u128), FractionalError> {
+            if lp_amount == 0 {
+                return Err(FractionalError::ZeroAmount);
+            }
+            let caller = self.env().caller();
+            let lp_held = self.lp_balances.get(&(caller, token_id)).unwrap_or(0);
+            if lp_held < lp_amount {
+                return Err(FractionalError::InsufficientLpShares);
+            }
+            let pool = self
+                .amm_pools
+                .get(token_id)
+                .ok_or(FractionalError::PoolNotFound)?;
+
+            let shares_out = lp_amount
+                .saturating_mul(pool.share_reserve)
+                .checked_div(pool.lp_supply)
+                .unwrap_or(0);
+            let value_out = lp_amount
+                .saturating_mul(pool.value_reserve)
+                .checked_div(pool.lp_supply)
+                .unwrap_or(0);
+
+            if shares_out < min_shares_out || value_out < min_value_out {
+                return Err(FractionalError::SlippageExceeded);
+            }
+
+            let updated = AmmPool {
+                share_reserve: pool.share_reserve.saturating_sub(shares_out),
+                value_reserve: pool.value_reserve.saturating_sub(value_out),
+                lp_supply: pool.lp_supply.saturating_sub(lp_amount),
+            };
+
+            // Return shares to caller
+            let bal = self.balances.get(&(caller, token_id)).unwrap_or(0);
+            self.balances
+                .insert(&(caller, token_id), &bal.saturating_add(shares_out));
+
+            self.lp_balances
+                .insert(&(caller, token_id), &lp_held.saturating_sub(lp_amount));
+            self.amm_pools.insert(token_id, &updated);
+
+            // Update spot price
+            if updated.share_reserve > 0 {
+                let spot = updated.value_reserve / updated.share_reserve;
+                self.last_prices.insert(token_id, &spot);
+            }
+
+            // Return value to caller (best-effort)
+            if value_out > 0 {
+                let _ = self.env().transfer(caller, value_out);
+            }
+
+            self.env().emit_event(LiquidityRemoved {
+                provider: caller,
+                token_id,
+                shares_out,
+                value_out,
+                lp_burned: lp_amount,
+            });
+            Ok((shares_out, value_out))
+        }
+
+        /// Sell `shares_in` shares into the AMM pool, receiving native value out.
+        /// Uses constant-product formula: value_out = value_reserve - k / (share_reserve + shares_in).
+        /// A 30-bip (0.3 %) fee is retained in the pool.
+        #[ink(message)]
+        pub fn swap_shares_for_value(
+            &mut self,
+            token_id: u64,
+            shares_in: u128,
+            min_value_out: u128,
+        ) -> Result<u128, FractionalError> {
+            if shares_in == 0 {
+                return Err(FractionalError::ZeroAmount);
+            }
+            let caller = self.env().caller();
+            let held = self.balances.get(&(caller, token_id)).unwrap_or(0);
+            if held < shares_in {
+                return Err(FractionalError::InsufficientShares);
+            }
+            let pool = self
+                .amm_pools
+                .get(token_id)
+                .ok_or(FractionalError::PoolNotFound)?;
+            if pool.value_reserve == 0 || pool.share_reserve == 0 {
+                return Err(FractionalError::InsufficientLiquidity);
+            }
+
+            // 0.3 % fee: effective shares_in after fee
+            let shares_in_with_fee = shares_in.saturating_mul(9970);
+            let numerator = shares_in_with_fee.saturating_mul(pool.value_reserve);
+            let denominator = pool
+                .share_reserve
+                .saturating_mul(10000)
+                .saturating_add(shares_in_with_fee);
+            let value_out = numerator.checked_div(denominator).unwrap_or(0);
+
+            if value_out < min_value_out {
+                return Err(FractionalError::SlippageExceeded);
+            }
+            if value_out >= pool.value_reserve {
+                return Err(FractionalError::InsufficientLiquidity);
+            }
+
+            let updated = AmmPool {
+                share_reserve: pool.share_reserve.saturating_add(shares_in),
+                value_reserve: pool.value_reserve.saturating_sub(value_out),
+                lp_supply: pool.lp_supply,
+            };
+
+            // Deduct shares from caller
+            self.balances
+                .insert(&(caller, token_id), &held.saturating_sub(shares_in));
+            // Burn shares from total supply
+            let total = self.total_shares.get(token_id).unwrap_or(0);
+            self.total_shares
+                .insert(token_id, &total.saturating_sub(shares_in));
+
+            // Update spot price
+            let new_spot = if updated.share_reserve > 0 {
+                let s = updated.value_reserve / updated.share_reserve;
+                self.last_prices.insert(token_id, &s);
+                s
+            } else {
+                0
+            };
+
+            self.amm_pools.insert(token_id, &updated);
+
+            // Pay caller (best-effort)
+            if value_out > 0 {
+                let _ = self.env().transfer(caller, value_out);
+            }
+
+            self.env().emit_event(SharesSwapped {
+                trader: caller,
+                token_id,
+                shares_in,
+                value_out,
+                new_spot_price: new_spot,
+            });
+            Ok(value_out)
+        }
+
+        /// Returns the current spot price (value per share) for `token_id`'s AMM pool.
+        /// Spot price = value_reserve / share_reserve.
+        #[ink(message)]
+        pub fn get_spot_price(&self, token_id: u64) -> Result<u128, FractionalError> {
+            let pool = self
+                .amm_pools
+                .get(token_id)
+                .ok_or(FractionalError::PoolNotFound)?;
+            if pool.share_reserve == 0 {
+                return Err(FractionalError::InsufficientLiquidity);
+            }
+            Ok(pool.value_reserve / pool.share_reserve)
+        }
+
+        /// Returns the AMM pool state for `token_id`.
+        #[ink(message)]
+        pub fn get_pool(&self, token_id: u64) -> Option<AmmPool> {
+            self.amm_pools.get(token_id)
+        }
+
+        /// Returns the LP token balance of `provider` for `token_id`.
+        #[ink(message)]
+        pub fn lp_balance_of(&self, provider: AccountId, token_id: u64) -> u128 {
+            self.lp_balances.get(&(provider, token_id)).unwrap_or(0)
+        }
+
+        // ── Helpers ──────────────────────────────────────────────────────────
+
+        /// Integer square root (floor).
+        fn isqrt(n: u128) -> u128 {
+            if n == 0 {
+                return 0;
+            }
+            let mut x = n;
+            let mut y = (x + 1) / 2;
+            while y < x {
+                x = y;
+                y = (x + n / x) / 2;
+            }
+            x
+        }
     }
 
     #[cfg(test)]
@@ -470,6 +813,163 @@ mod fractional {
                 f.buy_shares(alice(), 1, 10),
                 Err(FractionalError::InsufficientPayment)
             );
+        }
+
+        // ── AMM tests ────────────────────────────────────────────────────────
+
+        #[ink::test]
+        fn test_add_liquidity_creates_pool() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(500);
+            let lp = f.add_liquidity(1, 100, 0).unwrap();
+            assert!(lp > 0);
+
+            let pool = f.get_pool(1).unwrap();
+            assert_eq!(pool.share_reserve, 100);
+            assert_eq!(pool.value_reserve, 500);
+            assert_eq!(pool.lp_supply, lp);
+            assert_eq!(f.lp_balance_of(alice(), 1), lp);
+            // Shares locked: 1000 - 100 = 900
+            assert_eq!(f.balance_of(alice(), 1), 900);
+        }
+
+        #[ink::test]
+        fn test_add_liquidity_updates_spot_price() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(2000);
+            f.add_liquidity(1, 100, 0).unwrap();
+
+            // spot = 2000 / 100 = 20
+            assert_eq!(f.get_spot_price(1).unwrap(), 20);
+            assert_eq!(f.get_last_price(1), Some(20));
+        }
+
+        #[ink::test]
+        fn test_add_liquidity_insufficient_shares() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 10);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(500);
+            assert_eq!(
+                f.add_liquidity(1, 100, 0),
+                Err(FractionalError::InsufficientShares)
+            );
+        }
+
+        #[ink::test]
+        fn test_add_liquidity_slippage_check() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(100);
+            // isqrt(100 * 100) = 100; require > 100 → SlippageExceeded
+            assert_eq!(
+                f.add_liquidity(1, 100, 101),
+                Err(FractionalError::SlippageExceeded)
+            );
+        }
+
+        #[ink::test]
+        fn test_remove_liquidity() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(1000);
+            let lp = f.add_liquidity(1, 200, 0).unwrap();
+
+            let (shares_out, value_out) = f.remove_liquidity(1, lp, 0, 0).unwrap();
+            assert_eq!(shares_out, 200);
+            assert_eq!(value_out, 1000);
+            // Pool should be empty
+            let pool = f.get_pool(1).unwrap();
+            assert_eq!(pool.share_reserve, 0);
+            assert_eq!(pool.value_reserve, 0);
+            // Shares returned to alice
+            assert_eq!(f.balance_of(alice(), 1), 1000);
+        }
+
+        #[ink::test]
+        fn test_remove_liquidity_insufficient_lp() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(500);
+            let lp = f.add_liquidity(1, 100, 0).unwrap();
+
+            assert_eq!(
+                f.remove_liquidity(1, lp + 1, 0, 0),
+                Err(FractionalError::InsufficientLpShares)
+            );
+        }
+
+        #[ink::test]
+        fn test_swap_shares_for_value() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            // Seed pool: 100 shares, 10_000 value → spot = 100
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(10_000);
+            f.add_liquidity(1, 100, 0).unwrap();
+
+            // Alice swaps 10 shares for value
+            let value_out = f.swap_shares_for_value(1, 10, 0).unwrap();
+            assert!(value_out > 0);
+            // After swap: share_reserve grows, value_reserve shrinks → spot decreases
+            let new_spot = f.get_spot_price(1).unwrap();
+            assert!(new_spot < 100);
+        }
+
+        #[ink::test]
+        fn test_swap_no_pool() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 100);
+            assert_eq!(
+                f.swap_shares_for_value(1, 10, 0),
+                Err(FractionalError::PoolNotFound)
+            );
+        }
+
+        #[ink::test]
+        fn test_swap_slippage_check() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(10_000);
+            f.add_liquidity(1, 100, 0).unwrap();
+
+            // Demand more value_out than the pool can give
+            assert_eq!(
+                f.swap_shares_for_value(1, 10, 10_000),
+                Err(FractionalError::SlippageExceeded)
+            );
+        }
+
+        #[ink::test]
+        fn test_get_spot_price_no_pool() {
+            let f = Fractional::new();
+            assert_eq!(f.get_spot_price(99), Err(FractionalError::PoolNotFound));
+        }
+
+        #[ink::test]
+        fn test_isqrt() {
+            assert_eq!(Fractional::isqrt(0), 0);
+            assert_eq!(Fractional::isqrt(1), 1);
+            assert_eq!(Fractional::isqrt(4), 2);
+            assert_eq!(Fractional::isqrt(9), 3);
+            assert_eq!(Fractional::isqrt(10_000), 100);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #269

Implements constant-product AMM (x·y=k) pricing for fractional ownership shares, giving every property token a live on-chain spot price that moves with supply and demand.

## Changes

**New types**
- `AmmPool` struct — `share_reserve`, `value_reserve`, `lp_supply`
- 5 new `FractionalError` variants: `PoolNotFound`, `PoolAlreadyExists`, `SlippageExceeded`, `InsufficientLiquidity`, `InsufficientLpShares`

**New storage**
- `amm_pools: Mapping<u64, AmmPool>`
- `lp_balances: Mapping<(AccountId, u64), u128>`

**New messages**
| Message | Description |
|---|---|
| `add_liquidity(token_id, share_amount, min_lp_out)` | Seed/grow pool; mints LP tokens via integer sqrt |
| `remove_liquidity(token_id, lp_amount, min_shares_out, min_value_out)` | Burn LP, withdraw proportional reserves |
| `swap_shares_for_value(token_id, shares_in, min_value_out)` | Sell shares into pool with 0.3 % fee |
| `get_spot_price(token_id)` | Read current value/share from pool |
| `get_pool(token_id)` | Read full pool state |
| `lp_balance_of(provider, token_id)` | Read LP balance |

**Pricing integration**
- `last_prices` is updated after every pool mutation, so `aggregate_portfolio` and `redeem_shares` automatically use the AMM-derived price.

**New events**: `LiquidityAdded`, `LiquidityRemoved`, `SharesSwapped`

## Tests

10 new `#[ink::test]` cases covering pool creation, spot price updates, slippage guards, full removal, swap mechanics, and error paths.