### PR TITLE
feat(fractional): fractional ownership analytics / performance metrics (#273)

### DIFF
--- a/contracts/fractional/src/lib.rs
+++ b/contracts/fractional/src/lib.rs
@@ -70,6 +70,30 @@ mod fractional {
         pub price_per_share: u128,
     }
 
+    /// Per-token performance metrics for fractional ownership analytics.
+    #[derive(
+        Debug,
+        Clone,
+        PartialEq,
+        Eq,
+        scale::Encode,
+        scale::Decode,
+        ink::storage::traits::StorageLayout,
+    )]
+    #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+    pub struct FractionalMetrics {
+        /// Number of completed share trades (buy_shares + swap_shares_for_value).
+        pub trade_count: u64,
+        /// Cumulative value exchanged across all trades.
+        pub total_volume: u128,
+        /// Number of distinct accounts that currently hold shares.
+        pub unique_holders: u64,
+        /// Highest price-per-share ever recorded for this token.
+        pub all_time_high_price: u128,
+        /// Lowest non-zero price-per-share ever recorded for this token.
+        pub all_time_low_price: u128,
+    }
+
     #[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
     #[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
     pub enum FractionalError {
@@ -129,6 +153,10 @@ mod fractional {
         listings: Mapping<(AccountId, u64), ShareListing>,
         /// Total shares issued per token_id
         total_shares: Mapping<u64, u128>,
+        /// Performance metrics per token_id
+        token_metrics: Mapping<u64, FractionalMetrics>,
+        /// Tracks whether an account currently holds shares (for unique_holders count)
+        is_holder: Mapping<(AccountId, u64), bool>,
     }
 
     impl Fractional {
@@ -139,6 +167,8 @@ mod fractional {
                 balances: Mapping::default(),
                 listings: Mapping::default(),
                 total_shares: Mapping::default(),
+                token_metrics: Mapping::default(),
+                is_holder: Mapping::default(),
             }
         }
     }
@@ -207,9 +237,11 @@ mod fractional {
         #[ink(message)]
         pub fn mint_shares(&mut self, owner: AccountId, token_id: u64, amount: u128) {
             let current = self.balances.get(&(owner, token_id)).unwrap_or(0);
-            self.balances.insert(&(owner, token_id), &current.saturating_add(amount));
+            let new_bal = current.saturating_add(amount);
+            self.balances.insert(&(owner, token_id), &new_bal);
             let total = self.total_shares.get(&token_id).unwrap_or(0);
             self.total_shares.insert(&token_id, &total.saturating_add(amount));
+            self.update_holder(owner, token_id, new_bal);
         }
 
         /// Get the share balance of an owner for a given token
@@ -324,6 +356,14 @@ mod fractional {
                 // Non-fatal: payment forwarding failed (e.g. in unit tests)
             }
 
+            // Analytics: record trade and update holder counts
+            let price_per_share = listing.price_per_share;
+            let seller_new_bal = self.balances.get(&(seller, token_id)).unwrap_or(0);
+            let buyer_new_bal = self.balances.get(&(buyer, token_id)).unwrap_or(0);
+            self.record_trade(token_id, total_price, price_per_share);
+            self.update_holder(seller, token_id, seller_new_bal);
+            self.update_holder(buyer, token_id, buyer_new_bal);
+
             self.env().emit_event(SharesSold {
                 seller,
                 buyer,
@@ -366,6 +406,11 @@ mod fractional {
                 let _ = self.env().transfer(caller, payout);
             }
 
+            // Analytics: record redemption as a trade and update holder count
+            let new_bal = self.balances.get(&(caller, token_id)).unwrap_or(0);
+            self.record_trade(token_id, payout, price);
+            self.update_holder(caller, token_id, new_bal);
+
             self.env().emit_event(SharesRedeemed {
                 owner: caller,
                 token_id,
@@ -379,6 +424,57 @@ mod fractional {
         #[ink(message)]
         pub fn get_listing(&self, seller: AccountId, token_id: u64) -> Option<ShareListing> {
             self.listings.get(&(seller, token_id))
+        }
+
+        // ── Issue #273: Fractional ownership analytics ───────────────────────
+
+        /// Returns the performance metrics for `token_id`.
+        #[ink(message)]
+        pub fn get_metrics(&self, token_id: u64) -> FractionalMetrics {
+            self.token_metrics.get(token_id).unwrap_or(FractionalMetrics {
+                trade_count: 0,
+                total_volume: 0,
+                unique_holders: 0,
+                all_time_high_price: 0,
+                all_time_low_price: 0,
+            })
+        }
+
+        // ── Private analytics helpers ─────────────────────────────────────────
+
+        /// Record a completed trade: increment trade_count, add to total_volume,
+        /// and update all-time high/low price.
+        fn record_trade(&mut self, token_id: u64, volume: u128, price_per_share: u128) {
+            let mut m = self.get_metrics(token_id);
+            m.trade_count = m.trade_count.saturating_add(1);
+            m.total_volume = m.total_volume.saturating_add(volume);
+            if price_per_share > 0 {
+                if price_per_share > m.all_time_high_price {
+                    m.all_time_high_price = price_per_share;
+                }
+                if m.all_time_low_price == 0 || price_per_share < m.all_time_low_price {
+                    m.all_time_low_price = price_per_share;
+                }
+            }
+            self.token_metrics.insert(token_id, &m);
+        }
+
+        /// Update the unique_holders count when an account's balance crosses zero.
+        /// `new_balance` is the balance *after* the transfer.
+        fn update_holder(&mut self, account: AccountId, token_id: u64, new_balance: u128) {
+            let was_holder = self.is_holder.get(&(account, token_id)).unwrap_or(false);
+            let now_holder = new_balance > 0;
+            if was_holder == now_holder {
+                return;
+            }
+            self.is_holder.insert(&(account, token_id), &now_holder);
+            let mut m = self.get_metrics(token_id);
+            if now_holder {
+                m.unique_holders = m.unique_holders.saturating_add(1);
+            } else {
+                m.unique_holders = m.unique_holders.saturating_sub(1);
+            }
+            self.token_metrics.insert(token_id, &m);
         }
     }
 
@@ -470,6 +566,97 @@ mod fractional {
                 f.buy_shares(alice(), 1, 10),
                 Err(FractionalError::InsufficientPayment)
             );
+        }
+
+        // ── Analytics tests (#273) ────────────────────────────────────────────
+
+        #[ink::test]
+        fn test_metrics_default_zero() {
+            let f = Fractional::new();
+            let m = f.get_metrics(42);
+            assert_eq!(m.trade_count, 0);
+            assert_eq!(m.total_volume, 0);
+            assert_eq!(m.unique_holders, 0);
+            assert_eq!(m.all_time_high_price, 0);
+            assert_eq!(m.all_time_low_price, 0);
+        }
+
+        #[ink::test]
+        fn test_mint_increments_unique_holders() {
+            let mut f = Fractional::new();
+            f.mint_shares(alice(), 1, 100);
+            assert_eq!(f.get_metrics(1).unique_holders, 1);
+            // Minting more to same account doesn't double-count
+            f.mint_shares(alice(), 1, 50);
+            assert_eq!(f.get_metrics(1).unique_holders, 1);
+            // New account increments
+            f.mint_shares(bob(), 1, 200);
+            assert_eq!(f.get_metrics(1).unique_holders, 2);
+        }
+
+        #[ink::test]
+        fn test_redeem_decrements_unique_holders() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 100);
+            f.set_last_price(1, 5);
+            assert_eq!(f.get_metrics(1).unique_holders, 1);
+            // Redeem all shares → holder count drops to 0
+            f.redeem_shares(1, 100).unwrap();
+            assert_eq!(f.get_metrics(1).unique_holders, 0);
+        }
+
+        #[ink::test]
+        fn test_redeem_records_trade_volume_and_count() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 100);
+            f.set_last_price(1, 10);
+            f.redeem_shares(1, 50).unwrap(); // payout = 500
+            let m = f.get_metrics(1);
+            assert_eq!(m.trade_count, 1);
+            assert_eq!(m.total_volume, 500);
+        }
+
+        #[ink::test]
+        fn test_all_time_high_and_low_price() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            // First redemption at price 10
+            f.set_last_price(1, 10);
+            f.redeem_shares(1, 10).unwrap();
+            let m = f.get_metrics(1);
+            assert_eq!(m.all_time_high_price, 10);
+            assert_eq!(m.all_time_low_price, 10);
+
+            // Second redemption at higher price 20
+            f.set_last_price(1, 20);
+            f.redeem_shares(1, 10).unwrap();
+            let m = f.get_metrics(1);
+            assert_eq!(m.all_time_high_price, 20);
+            assert_eq!(m.all_time_low_price, 10); // low unchanged
+
+            // Third redemption at lower price 5
+            f.set_last_price(1, 5);
+            f.redeem_shares(1, 10).unwrap();
+            let m = f.get_metrics(1);
+            assert_eq!(m.all_time_high_price, 20); // high unchanged
+            assert_eq!(m.all_time_low_price, 5);
+        }
+
+        #[ink::test]
+        fn test_cumulative_volume_across_trades() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+            f.set_last_price(1, 10);
+            f.redeem_shares(1, 10).unwrap(); // 100
+            f.redeem_shares(1, 20).unwrap(); // 200
+            let m = f.get_metrics(1);
+            assert_eq!(m.trade_count, 2);
+            assert_eq!(m.total_volume, 300);
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #273

Tracks per-token performance metrics directly inside the fractional ownership contract, where the authoritative share data lives.

## Changes

**New type**
- `FractionalMetrics` — `trade_count`, `total_volume`, `unique_holders`, `all_time_high_price`, `all_time_low_price`

**New storage**
- `token_metrics: Mapping<u64, FractionalMetrics>` — one record per property token
- `is_holder: Mapping<(AccountId, u64), bool>` — tracks whether an account currently holds shares, used to maintain an accurate `unique_holders` count without iterating

**New message**
- `get_metrics(token_id) -> FractionalMetrics` — read-only query; returns zero-valued struct for unknown tokens

**Private helpers**
- `record_trade(token_id, volume, price_per_share)` — increments `trade_count`, adds to `total_volume`, updates ATH/ATL
- `update_holder(account, token_id, new_balance)` — adjusts `unique_holders` only when an account crosses the zero-balance boundary

**Hooks added to existing messages**
| Message | What is recorded |
|---|---|
| `mint_shares` | `update_holder` on recipient |
| `buy_shares` | `record_trade` (volume + price) + `update_holder` on seller and buyer |
| `redeem_shares` | `record_trade` (payout + last price) + `update_holder` on redeemer |

## Tests

6 new `#[ink::test]` cases:
- Default metrics are all zero for unknown token
- `mint_shares` increments `unique_holders` (no double-count for same account)
- `redeem_shares` (all shares) decrements `unique_holders` to 0
- `redeem_shares` records `trade_count` and `total_volume`
- ATH/ATL price tracking across multiple trades
- Cumulative volume accumulates correctly across trades