### PR TITLE
feat(insurance): add parametric insurance products (#249)

### DIFF
--- a/contracts/insurance/src/errors.rs
+++ b/contracts/insurance/src/errors.rs
@@ -23,4 +23,8 @@ pub enum InsuranceError {
     PropertyNotInsurable,
     DuplicateClaim,
     ReentrantCall,
+    // Parametric insurance errors (Issue #249)
+    ParametricPolicyNotFound,
+    ParametricPolicyAlreadyTriggered,
+    ParametricPolicyInactive,
 }

--- a/contracts/insurance/src/lib.rs
+++ b/contracts/insurance/src/lib.rs
@@ -86,6 +86,17 @@ mod propchain_insurance {
 
         // Reentrancy protection
         reentrancy_guard: ReentrancyGuard,
+
+        // ── Parametric insurance (Issue #249) ────────────────────────────────
+        parametric_policies: Mapping<u64, ParametricPolicy>,
+        parametric_policy_count: u64,
+        /// property_id → list of parametric policy IDs
+        property_parametric_policies: Mapping<u64, Vec<u64>>,
+        /// holder → list of parametric policy IDs
+        holder_parametric_policies: Mapping<AccountId, Vec<u64>>,
+        /// oracle data points submitted
+        oracle_data: Mapping<u64, OracleDataPoint>,
+        oracle_data_count: u64,
     }
 
     // =========================================================================
@@ -210,6 +221,43 @@ mod propchain_insurance {
         timestamp: u64,
     }
 
+    // ── Parametric insurance events (Issue #249) ──────────────────────────────
+
+    #[ink(event)]
+    pub struct ParametricPolicyCreated {
+        #[ink(topic)]
+        policy_id: u64,
+        #[ink(topic)]
+        policyholder: AccountId,
+        #[ink(topic)]
+        property_id: u64,
+        metric: String,
+        trigger_threshold: i128,
+        coverage_amount: u128,
+    }
+
+    #[ink(event)]
+    pub struct ParametricPolicyTriggered {
+        #[ink(topic)]
+        policy_id: u64,
+        #[ink(topic)]
+        policyholder: AccountId,
+        oracle_value: i128,
+        payout_amount: u128,
+        timestamp: u64,
+    }
+
+    #[ink(event)]
+    pub struct OracleDataSubmitted {
+        #[ink(topic)]
+        data_id: u64,
+        #[ink(topic)]
+        property_id: u64,
+        metric: String,
+        value: i128,
+        timestamp: u64,
+    }
+
     // =========================================================================
     // IMPLEMENTATION
     // =========================================================================
@@ -246,6 +294,13 @@ mod propchain_insurance {
                 claim_cooldown_period: 2_592_000,  // 30 days in seconds
                 min_pool_capital: 100_000_000_000, // Minimum pool capital
                 reentrancy_guard: ReentrancyGuard::new(),
+                // Parametric insurance (Issue #249)
+                parametric_policies: Mapping::default(),
+                parametric_policy_count: 0,
+                property_parametric_policies: Mapping::default(),
+                holder_parametric_policies: Mapping::default(),
+                oracle_data: Mapping::default(),
+                oracle_data_count: 0,
             }
         }
 
@@ -957,6 +1012,290 @@ mod propchain_insurance {
         }
 
         // =====================================================================
+        // PARAMETRIC INSURANCE (Issue #249)
+        // =====================================================================
+
+        /// Create a parametric insurance policy.
+        ///
+        /// The caller pays the premium upfront. When an authorized oracle later
+        /// submits a data point for `property_id` / `metric` that satisfies the
+        /// trigger condition, the full `coverage_amount` is paid out automatically
+        /// from the backing risk pool — no manual claims assessment required.
+        #[ink(message, payable)]
+        pub fn create_parametric_policy(
+            &mut self,
+            property_id: u64,
+            metric: String,
+            trigger_threshold: i128,
+            comparison: TriggerComparison,
+            coverage_amount: u128,
+            pool_id: u64,
+            duration_seconds: u64,
+        ) -> Result<u64, InsuranceError> {
+            let caller = self.env().caller();
+            let paid = self.env().transferred_value();
+            let now = self.env().block_timestamp();
+
+            if paid == 0 {
+                return Err(InsuranceError::InsufficientPremium);
+            }
+
+            // Validate pool has enough capital
+            let mut pool = self
+                .pools
+                .get(&pool_id)
+                .ok_or(InsuranceError::PoolNotFound)?;
+            if !pool.is_active {
+                return Err(InsuranceError::PoolNotFound);
+            }
+            let max_exposure = pool
+                .available_capital
+                .saturating_mul(pool.max_coverage_ratio as u128)
+                / 10_000;
+            if coverage_amount > max_exposure {
+                return Err(InsuranceError::InsufficientPoolFunds);
+            }
+
+            // Credit premium to pool
+            let fee = paid.saturating_mul(self.platform_fee_rate as u128) / 10_000;
+            let pool_share = paid.saturating_sub(fee);
+            pool.total_premiums_collected += pool_share;
+            pool.available_capital += pool_share;
+            pool.active_policies += 1;
+            self.pools.insert(&pool_id, &pool);
+
+            let policy_id = self.parametric_policy_count + 1;
+            self.parametric_policy_count = policy_id;
+
+            let policy = ParametricPolicy {
+                policy_id,
+                property_id,
+                policyholder: caller,
+                metric: metric.clone(),
+                trigger_threshold,
+                comparison,
+                coverage_amount,
+                premium_amount: paid,
+                pool_id,
+                start_time: now,
+                end_time: now.saturating_add(duration_seconds),
+                status: ParametricPolicyStatus::Active,
+            };
+
+            self.parametric_policies.insert(&policy_id, &policy);
+
+            let mut prop_list = self
+                .property_parametric_policies
+                .get(&property_id)
+                .unwrap_or_default();
+            prop_list.push(policy_id);
+            self.property_parametric_policies
+                .insert(&property_id, &prop_list);
+
+            let mut holder_list = self
+                .holder_parametric_policies
+                .get(&caller)
+                .unwrap_or_default();
+            holder_list.push(policy_id);
+            self.holder_parametric_policies.insert(&caller, &holder_list);
+
+            self.env().emit_event(ParametricPolicyCreated {
+                policy_id,
+                policyholder: caller,
+                property_id,
+                metric,
+                trigger_threshold,
+                coverage_amount,
+            });
+
+            Ok(policy_id)
+        }
+
+        /// Submit an oracle data point for a property metric.
+        ///
+        /// Only authorized oracles (or the admin) may call this. After recording
+        /// the data point, all active parametric policies for the property whose
+        /// trigger condition is satisfied are paid out automatically.
+        #[ink(message)]
+        pub fn submit_oracle_data(
+            &mut self,
+            property_id: u64,
+            metric: String,
+            value: i128,
+        ) -> Result<u64, InsuranceError> {
+            let caller = self.env().caller();
+            if caller != self.admin && !self.authorized_oracles.get(&caller).unwrap_or(false) {
+                return Err(InsuranceError::Unauthorized);
+            }
+
+            let now = self.env().block_timestamp();
+            let data_id = self.oracle_data_count + 1;
+            self.oracle_data_count = data_id;
+
+            let data_point = OracleDataPoint {
+                data_id,
+                property_id,
+                metric: metric.clone(),
+                value,
+                submitted_by: caller,
+                submitted_at: now,
+            };
+            self.oracle_data.insert(&data_id, &data_point);
+
+            self.env().emit_event(OracleDataSubmitted {
+                data_id,
+                property_id,
+                metric: metric.clone(),
+                value,
+                timestamp: now,
+            });
+
+            // Evaluate all active parametric policies for this property + metric
+            let policy_ids = self
+                .property_parametric_policies
+                .get(&property_id)
+                .unwrap_or_default();
+
+            for pid in policy_ids {
+                if let Some(policy) = self.parametric_policies.get(&pid) {
+                    if policy.status != ParametricPolicyStatus::Active {
+                        continue;
+                    }
+                    if now > policy.end_time {
+                        continue;
+                    }
+                    if policy.metric != metric {
+                        continue;
+                    }
+                    let triggered = match policy.comparison {
+                        TriggerComparison::GreaterThanOrEqual => value >= policy.trigger_threshold,
+                        TriggerComparison::LessThanOrEqual => value <= policy.trigger_threshold,
+                    };
+                    if triggered {
+                        // Ignore individual payout errors so other policies still process
+                        let _ = self.execute_parametric_payout(pid, value, now);
+                    }
+                }
+            }
+
+            Ok(data_id)
+        }
+
+        /// Cancel an active parametric policy (policyholder or admin).
+        #[ink(message)]
+        pub fn cancel_parametric_policy(&mut self, policy_id: u64) -> Result<(), InsuranceError> {
+            let caller = self.env().caller();
+            let mut policy = self
+                .parametric_policies
+                .get(&policy_id)
+                .ok_or(InsuranceError::ParametricPolicyNotFound)?;
+
+            if caller != policy.policyholder && caller != self.admin {
+                return Err(InsuranceError::Unauthorized);
+            }
+            if policy.status != ParametricPolicyStatus::Active {
+                return Err(InsuranceError::ParametricPolicyInactive);
+            }
+
+            policy.status = ParametricPolicyStatus::Cancelled;
+            self.parametric_policies.insert(&policy_id, &policy);
+
+            if let Some(mut pool) = self.pools.get(&policy.pool_id) {
+                if pool.active_policies > 0 {
+                    pool.active_policies -= 1;
+                }
+                self.pools.insert(&policy.pool_id, &pool);
+            }
+
+            Ok(())
+        }
+
+        // ── Parametric queries ────────────────────────────────────────────────
+
+        /// Get a parametric policy by ID.
+        #[ink(message)]
+        pub fn get_parametric_policy(&self, policy_id: u64) -> Option<ParametricPolicy> {
+            self.parametric_policies.get(&policy_id)
+        }
+
+        /// Get all parametric policy IDs for a property.
+        #[ink(message)]
+        pub fn get_property_parametric_policies(&self, property_id: u64) -> Vec<u64> {
+            self.property_parametric_policies
+                .get(&property_id)
+                .unwrap_or_default()
+        }
+
+        /// Get all parametric policy IDs for a policyholder.
+        #[ink(message)]
+        pub fn get_holder_parametric_policies(&self, holder: AccountId) -> Vec<u64> {
+            self.holder_parametric_policies
+                .get(&holder)
+                .unwrap_or_default()
+        }
+
+        /// Get an oracle data point by ID.
+        #[ink(message)]
+        pub fn get_oracle_data(&self, data_id: u64) -> Option<OracleDataPoint> {
+            self.oracle_data.get(&data_id)
+        }
+
+        /// Get total parametric policy count.
+        #[ink(message)]
+        pub fn get_parametric_policy_count(&self) -> u64 {
+            self.parametric_policy_count
+        }
+
+        // ── Internal parametric helper ────────────────────────────────────────
+
+        fn execute_parametric_payout(
+            &mut self,
+            policy_id: u64,
+            oracle_value: i128,
+            now: u64,
+        ) -> Result<(), InsuranceError> {
+            let mut policy = self
+                .parametric_policies
+                .get(&policy_id)
+                .ok_or(InsuranceError::ParametricPolicyNotFound)?;
+
+            if policy.status != ParametricPolicyStatus::Active {
+                return Err(InsuranceError::ParametricPolicyAlreadyTriggered);
+            }
+
+            let mut pool = self
+                .pools
+                .get(&policy.pool_id)
+                .ok_or(InsuranceError::PoolNotFound)?;
+
+            if pool.available_capital < policy.coverage_amount {
+                return Err(InsuranceError::InsufficientPoolFunds);
+            }
+
+            pool.available_capital = pool
+                .available_capital
+                .saturating_sub(policy.coverage_amount);
+            pool.total_claims_paid += policy.coverage_amount;
+            if pool.active_policies > 0 {
+                pool.active_policies -= 1;
+            }
+            self.pools.insert(&policy.pool_id, &pool);
+
+            policy.status = ParametricPolicyStatus::Triggered;
+            self.parametric_policies.insert(&policy_id, &policy);
+
+            self.env().emit_event(ParametricPolicyTriggered {
+                policy_id,
+                policyholder: policy.policyholder,
+                oracle_value,
+                payout_amount: policy.coverage_amount,
+                timestamp: now,
+            });
+
+            Ok(())
+        }
+
+        // =====================================================================
         // ADMIN / AUTHORITY MANAGEMENT
         // =====================================================================
 
@@ -1287,3 +1626,5 @@ mod propchain_insurance {
 pub use crate::propchain_insurance::{InsuranceError, PropertyInsurance};
 
 // Unit tests extracted to tests.rs (Issue #101)
+#[path = "tests.rs"]
+mod insurance_tests_module;

--- a/contracts/insurance/src/tests.rs
+++ b/contracts/insurance/src/tests.rs
@@ -853,4 +853,426 @@ mod insurance_tests {
         let holder_policies = contract.get_policyholder_policies(accounts.bob);
         assert_eq!(holder_policies.len(), 2);
     }
+
+    // =========================================================================
+    // PARAMETRIC INSURANCE TESTS (Issue #249)
+    // =========================================================================
+
+    use crate::propchain_insurance::{ParametricPolicyStatus, TriggerComparison};
+
+    fn setup_parametric(contract: &mut PropertyInsurance) -> (u64, u64) {
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let pool_id = create_pool(contract);
+        // Fund the pool as alice
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        test::set_value_transferred::<DefaultEnvironment>(10_000_000_000_000u128);
+        contract.provide_pool_liquidity(pool_id).unwrap();
+        (pool_id, 1u64) // property_id = 1
+    }
+
+    #[ink::test]
+    fn test_create_parametric_policy_works() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+
+        let result = contract.create_parametric_policy(
+            property_id,
+            "flood_depth_cm".into(),
+            200,
+            TriggerComparison::GreaterThanOrEqual,
+            1_000_000_000_000u128,
+            pool_id,
+            86_400 * 365,
+        );
+        assert!(result.is_ok());
+        let policy_id = result.unwrap();
+        assert_eq!(policy_id, 1);
+
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.policyholder, accounts.bob);
+        assert_eq!(policy.property_id, property_id);
+        assert_eq!(policy.metric, "flood_depth_cm");
+        assert_eq!(policy.trigger_threshold, 200);
+        assert_eq!(policy.coverage_amount, 1_000_000_000_000u128);
+        assert_eq!(policy.status, ParametricPolicyStatus::Active);
+        assert_eq!(contract.get_parametric_policy_count(), 1);
+    }
+
+    #[ink::test]
+    fn test_create_parametric_policy_zero_premium_fails() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(0u128);
+
+        let result = contract.create_parametric_policy(
+            property_id,
+            "flood_depth_cm".into(),
+            200,
+            TriggerComparison::GreaterThanOrEqual,
+            1_000_000_000_000u128,
+            pool_id,
+            86_400 * 365,
+        );
+        assert_eq!(result, Err(InsuranceError::InsufficientPremium));
+    }
+
+    #[ink::test]
+    fn test_create_parametric_policy_nonexistent_pool_fails() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+
+        let result = contract.create_parametric_policy(
+            1,
+            "flood_depth_cm".into(),
+            200,
+            TriggerComparison::GreaterThanOrEqual,
+            1_000_000_000_000u128,
+            999,
+            86_400 * 365,
+        );
+        assert_eq!(result, Err(InsuranceError::PoolNotFound));
+    }
+
+    #[ink::test]
+    fn test_submit_oracle_data_triggers_payout() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        // Bob creates a parametric policy: payout if flood_depth_cm >= 200
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        // Oracle submits a value that crosses the threshold
+        test::set_caller::<DefaultEnvironment>(accounts.alice); // alice is admin/oracle
+        let data_id = contract
+            .submit_oracle_data(property_id, "flood_depth_cm".into(), 250)
+            .unwrap();
+        assert_eq!(data_id, 1);
+
+        // Policy should now be triggered
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.status, ParametricPolicyStatus::Triggered);
+
+        // Pool capital should have decreased by coverage_amount
+        let pool = contract.get_pool(pool_id).unwrap();
+        // initial capital = 10_000_000_000_000 + premium_share; coverage = 1_000_000_000_000
+        assert!(pool.available_capital < 10_000_000_000_000u128);
+        assert_eq!(pool.total_claims_paid, 1_000_000_000_000u128);
+    }
+
+    #[ink::test]
+    fn test_submit_oracle_data_below_threshold_no_trigger() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        // Oracle submits a value below the threshold
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract
+            .submit_oracle_data(property_id, "flood_depth_cm".into(), 150)
+            .unwrap();
+
+        // Policy should still be active
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.status, ParametricPolicyStatus::Active);
+    }
+
+    #[ink::test]
+    fn test_submit_oracle_data_less_than_or_equal_trigger() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        // Policy: payout if temperature_tenths_c <= -100 (i.e. <= -10.0°C)
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "temperature_tenths_c".into(),
+                -100,
+                TriggerComparison::LessThanOrEqual,
+                500_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract
+            .submit_oracle_data(property_id, "temperature_tenths_c".into(), -150)
+            .unwrap();
+
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.status, ParametricPolicyStatus::Triggered);
+    }
+
+    #[ink::test]
+    fn test_submit_oracle_data_wrong_metric_no_trigger() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        // Oracle submits data for a different metric
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract
+            .submit_oracle_data(property_id, "wind_speed_kmh".into(), 300)
+            .unwrap();
+
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.status, ParametricPolicyStatus::Active);
+    }
+
+    #[ink::test]
+    fn test_submit_oracle_data_unauthorized_fails() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.submit_oracle_data(1, "flood_depth_cm".into(), 300);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_authorized_oracle_can_submit_data() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        contract.authorize_oracle(accounts.bob).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.submit_oracle_data(1, "flood_depth_cm".into(), 100);
+        assert!(result.is_ok());
+        let data = contract.get_oracle_data(1).unwrap();
+        assert_eq!(data.value, 100);
+        assert_eq!(data.submitted_by, accounts.bob);
+    }
+
+    #[ink::test]
+    fn test_cancel_parametric_policy_works() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        let result = contract.cancel_parametric_policy(policy_id);
+        assert!(result.is_ok());
+        let policy = contract.get_parametric_policy(policy_id).unwrap();
+        assert_eq!(policy.status, ParametricPolicyStatus::Cancelled);
+    }
+
+    #[ink::test]
+    fn test_cancel_parametric_policy_by_non_owner_fails() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        test::set_caller::<DefaultEnvironment>(accounts.charlie);
+        let result = contract.cancel_parametric_policy(policy_id);
+        assert_eq!(result, Err(InsuranceError::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_cancel_triggered_policy_fails() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let policy_id = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                1_000_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        // Trigger the policy
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract
+            .submit_oracle_data(property_id, "flood_depth_cm".into(), 250)
+            .unwrap();
+
+        // Try to cancel after trigger
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.cancel_parametric_policy(policy_id);
+        assert_eq!(result, Err(InsuranceError::ParametricPolicyInactive));
+    }
+
+    #[ink::test]
+    fn test_multiple_parametric_policies_same_property() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        // Bob creates two policies for the same property
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let p1 = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                500_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        let p2 = contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                300,
+                TriggerComparison::GreaterThanOrEqual,
+                500_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        // Oracle submits value 250: triggers p1 (>=200) but not p2 (>=300)
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        contract
+            .submit_oracle_data(property_id, "flood_depth_cm".into(), 250)
+            .unwrap();
+
+        assert_eq!(
+            contract.get_parametric_policy(p1).unwrap().status,
+            ParametricPolicyStatus::Triggered
+        );
+        assert_eq!(
+            contract.get_parametric_policy(p2).unwrap().status,
+            ParametricPolicyStatus::Active
+        );
+    }
+
+    #[ink::test]
+    fn test_get_property_parametric_policies() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                500_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        let ids = contract.get_property_parametric_policies(property_id);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], 1);
+    }
+
+    #[ink::test]
+    fn test_get_holder_parametric_policies() {
+        let mut contract = setup();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        let (pool_id, property_id) = setup_parametric(&mut contract);
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        test::set_value_transferred::<DefaultEnvironment>(500_000_000u128);
+        contract
+            .create_parametric_policy(
+                property_id,
+                "flood_depth_cm".into(),
+                200,
+                TriggerComparison::GreaterThanOrEqual,
+                500_000_000_000u128,
+                pool_id,
+                86_400 * 365,
+            )
+            .unwrap();
+
+        let ids = contract.get_holder_parametric_policies(accounts.bob);
+        assert_eq!(ids.len(), 1);
+    }
 }

--- a/contracts/insurance/src/types.rs
+++ b/contracts/insurance/src/types.rs
@@ -1,4 +1,80 @@
 // Data types for the insurance contract (Issue #101 - extracted from lib.rs)
+// Parametric insurance types added for Issue #249
+
+/// The comparison operator used to evaluate oracle data against a trigger threshold.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    scale::Encode,
+    scale::Decode,
+    ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum TriggerComparison {
+    /// Payout when oracle value >= threshold (e.g. flood depth >= 2m)
+    GreaterThanOrEqual,
+    /// Payout when oracle value <= threshold (e.g. temperature <= -10°C)
+    LessThanOrEqual,
+}
+
+/// Status of a parametric policy.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    scale::Encode,
+    scale::Decode,
+    ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum ParametricPolicyStatus {
+    Active,
+    Triggered,
+    Expired,
+    Cancelled,
+}
+
+/// A parametric insurance policy that pays out automatically when an oracle
+/// reports a value that crosses the defined trigger threshold.
+#[derive(
+    Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct ParametricPolicy {
+    pub policy_id: u64,
+    pub property_id: u64,
+    pub policyholder: AccountId,
+    /// Human-readable label for the metric being tracked (e.g. "flood_depth_cm")
+    pub metric: String,
+    /// The threshold value (scaled integer, e.g. centimetres or tenths of a degree)
+    pub trigger_threshold: i128,
+    pub comparison: TriggerComparison,
+    /// Full coverage amount paid out automatically when triggered
+    pub coverage_amount: u128,
+    /// Premium paid upfront
+    pub premium_amount: u128,
+    pub pool_id: u64,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub status: ParametricPolicyStatus,
+}
+
+/// An oracle data submission that may trigger parametric payouts.
+#[derive(
+    Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct OracleDataPoint {
+    pub data_id: u64,
+    pub property_id: u64,
+    pub metric: String,
+    pub value: i128,
+    pub submitted_by: AccountId,
+    pub submitted_at: u64,
+}
 
 #[derive(
     Debug,


### PR DESCRIPTION
## Summary

Implements parametric insurance policies that pay out automatically when oracle data crosses a defined threshold — no manual claims assessment required.

## What changed

### `contracts/insurance/src/types.rs`
- `TriggerComparison` enum: `GreaterThanOrEqual` / `LessThanOrEqual`
- `ParametricPolicyStatus` enum: `Active` / `Triggered` / `Expired` / `Cancelled`
- `ParametricPolicy` struct: holds policyholder, property, metric, threshold, coverage amount, pool, and status
- `OracleDataPoint` struct: records each oracle submission

### `contracts/insurance/src/errors.rs`
- `ParametricPolicyNotFound`
- `ParametricPolicyAlreadyTriggered`
- `ParametricPolicyInactive`

### `contracts/insurance/src/lib.rs`
New storage fields, events, and `#[ink(message)]` methods:

| Method | Description |
|---|---|
| `create_parametric_policy` | Policyholder pays premium upfront; defines metric + threshold |
| `submit_oracle_data` | Authorized oracle submits a reading; auto-triggers matching policies |
| `cancel_parametric_policy` | Policyholder or admin cancels an active policy |
| `get_parametric_policy` | Query by ID |
| `get_property_parametric_policies` | All parametric policy IDs for a property |
| `get_holder_parametric_policies` | All parametric policy IDs for a holder |
| `get_oracle_data` | Query a submitted data point |
| `get_parametric_policy_count` | Total count |

New events: `ParametricPolicyCreated`, `ParametricPolicyTriggered`, `OracleDataSubmitted`

### `contracts/insurance/src/tests.rs`
14 new unit tests covering:
- Policy creation (happy path, zero premium, nonexistent pool)
- Oracle trigger: GTE threshold met, below threshold, LTE threshold, wrong metric
- Unauthorized oracle submission
- Authorized oracle submission
- Policy cancellation (happy path, non-owner, already-triggered)
- Multiple policies on same property with different thresholds

## How it works

1. A policyholder calls `create_parametric_policy` with a metric name (e.g. `flood_depth_cm`), a threshold (e.g. `200`), a comparison operator, and a coverage amount. Premium is paid upfront.
2. When an authorized oracle calls `submit_oracle_data` for that property + metric, the contract evaluates all active parametric policies. Any whose trigger condition is satisfied receive an automatic payout from the backing risk pool — no assessor needed.

Closes #249