### PR TITLE
fix(insurance): add missing InsuranceError variants for claim automation and parametric policies

### DIFF
--- a/contracts/insurance/src/errors.rs
+++ b/contracts/insurance/src/errors.rs
@@ -36,4 +36,14 @@ pub enum InsuranceError {
     ReinsuranceAgreementNotFound,
     ReinsuranceAgreementExpired,
     ReinsuranceAgreementInactive,
+    // Claim automation errors (#433)
+    TriggerNotFound,
+    TriggerInactive,
+    TriggerAlreadyFired,
+    TriggerConditionNotMet,
+    InvalidPayoutMode,
+    // Parametric policy errors (#433)
+    ParametricPolicyNotFound,
+    ParametricPolicyInactive,
+    ParametricPolicyAlreadyTriggered,
 }


### PR DESCRIPTION
## Summary
Adds all missing variants to contracts/insurance/src/errors.rs:

**Claim automation:** TriggerNotFound, TriggerInactive, TriggerAlreadyFired, TriggerConditionNotMet, InvalidPayoutMode

**Parametric policy:** ParametricPolicyNotFound, ParametricPolicyInactive, ParametricPolicyAlreadyTriggered

closes #433