### PR TITLE
fix(insurance): ANOMALOUS_CLAIM_MULTIPLIER type mismatch u32 vs u128

### DIFF
--- a/contracts/insurance/src/fraud_detection.rs
+++ b/contracts/insurance/src/fraud_detection.rs
@@ -13,7 +13,7 @@ pub mod fraud_detection {
     const CLAIMS_SHORT_PERIOD_DAYS: u64 = 30; // Days window for multiple claims
     const CLAIMS_SHORT_PERIOD_SECONDS: u64 = CLAIMS_SHORT_PERIOD_DAYS * 86_400;
     const SUSPICIOUS_TIME_WEEKEND_THRESHOLD: u32 = 200; // Extra points for weekend claims
-    const ANOMALOUS_CLAIM_MULTIPLIER: u32 = 150; // 150% of average
+    const ANOMALOUS_CLAIM_MULTIPLIER: u128 = 150; // 150% of average
     const HIGH_RISK_FRAUD_SCORE: u32 = 200;
 
     /// Detect multiple claims in a short time period


### PR DESCRIPTION
## Summary

Fixes #437

`ANOMALOUS_CLAIM_MULTIPLIER` was declared as `u32` but is compared against `multiplier`, which is `u128` (computed from `u128` arithmetic: `claim_amount * 100 / average_claim_amount`). This causes a type mismatch compile error.

## Change

```rust
// Before
const ANOMALOUS_CLAIM_MULTIPLIER: u32 = 150;

// After
const ANOMALOUS_CLAIM_MULTIPLIER: u128 = 150;
```

## Testing

The fix aligns the constant type with the `u128` operand it is compared against in `detect_anomalous_claim_amount`.