### PR TITLE
fix: resolve issues #487, #488, #489, #493

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6019,11 +6019,15 @@ name = "propchain-tests"
 version = "1.0.0"
 dependencies = [
  "compliance_registry",
+ "fractional",
+ "governance",
  "ink 5.1.1",
  "ink_e2e",
  "ink_env 5.1.1",
  "parity-scale-codec",
+ "propchain-bridge",
  "propchain-contracts",
+ "propchain-insurance",
  "propchain-monitoring",
  "propchain-traits",
  "property-token",
@@ -6032,6 +6036,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
+ "staking",
  "tax-compliance",
  "tokio",
 ]

--- a/contracts/fractional/src/lib.rs
+++ b/contracts/fractional/src/lib.rs
@@ -4,6 +4,7 @@
 mod fractional {
     use ink::prelude::vec::Vec;
     use ink::storage::Mapping;
+    use propchain_traits::{non_reentrant, ReentrancyGuard};
 
     #[derive(
         Debug,
@@ -117,6 +118,14 @@ mod fractional {
         SlippageExceeded,
         InsufficientLiquidity,
         InsufficientLpShares,
+        /// A reentrant call was detected (issue #493).
+        ReentrantCall,
+    }
+
+    impl From<propchain_traits::ReentrancyError> for FractionalError {
+        fn from(_: propchain_traits::ReentrancyError) -> Self {
+            FractionalError::ReentrantCall
+        }
     }
 
     /// Emitted when an owner lists shares for sale
@@ -205,6 +214,8 @@ mod fractional {
         amm_pools: Mapping<u64, AmmPool>,
         /// LP token balances per (provider, token_id)
         lp_balances: Mapping<(AccountId, u64), u128>,
+        /// Reentrancy protection (issue #493)
+        reentrancy_guard: ReentrancyGuard,
     }
 
     impl Fractional {
@@ -217,6 +228,7 @@ mod fractional {
                 total_shares: Mapping::default(),
                 amm_pools: Mapping::default(),
                 lp_balances: Mapping::default(),
+                reentrancy_guard: ReentrancyGuard::new(),
             }
         }
     }
@@ -374,6 +386,7 @@ mod fractional {
             token_id: u64,
             shares: u128,
         ) -> Result<(), FractionalError> {
+            non_reentrant!(self, {
             if shares == 0 {
                 return Err(FractionalError::ZeroAmount);
             }
@@ -436,6 +449,7 @@ mod fractional {
                 total_price,
             });
             Ok(())
+            })
         }
 
         /// Redeem shares for their proportional value based on the last recorded price.
@@ -446,6 +460,7 @@ mod fractional {
             token_id: u64,
             shares: u128,
         ) -> Result<u128, FractionalError> {
+            non_reentrant!(self, {
             if shares == 0 {
                 return Err(FractionalError::ZeroAmount);
             }
@@ -482,6 +497,7 @@ mod fractional {
                 payout,
             });
             Ok(payout)
+            })
         }
 
         /// Get an active listing
@@ -502,6 +518,7 @@ mod fractional {
             share_amount: u128,
             min_lp_out: u128,
         ) -> Result<u128, FractionalError> {
+            non_reentrant!(self, {
             if share_amount == 0 {
                 return Err(FractionalError::ZeroAmount);
             }
@@ -574,6 +591,7 @@ mod fractional {
                 lp_minted,
             });
             Ok(lp_minted)
+            })
         }
 
         /// Burn `lp_amount` LP tokens and withdraw proportional shares + value.
@@ -585,6 +603,7 @@ mod fractional {
             min_shares_out: u128,
             min_value_out: u128,
         ) -> Result<(u128, u128), FractionalError> {
+            non_reentrant!(self, {
             if lp_amount == 0 {
                 return Err(FractionalError::ZeroAmount);
             }
@@ -645,6 +664,7 @@ mod fractional {
                 lp_burned: lp_amount,
             });
             Ok((shares_out, value_out))
+            })
         }
 
         /// Sell `shares_in` shares into the AMM pool, receiving native value out.
@@ -657,6 +677,7 @@ mod fractional {
             shares_in: u128,
             min_value_out: u128,
         ) -> Result<u128, FractionalError> {
+            non_reentrant!(self, {
             if shares_in == 0 {
                 return Err(FractionalError::ZeroAmount);
             }
@@ -727,6 +748,7 @@ mod fractional {
                 new_spot_price: new_spot,
             });
             Ok(value_out)
+            })
         }
 
         /// Returns the current spot price (value per share) for `token_id`'s AMM pool.
@@ -770,6 +792,12 @@ mod fractional {
             }
             x
         }
+
+        /// Record a trade for analytics (no-op stub — extend for on-chain analytics).
+        fn record_trade(&mut self, _token_id: u64, _volume: u128, _price: u128) {}
+
+        /// Update the holder count for analytics (no-op stub — extend for on-chain analytics).
+        fn update_holder(&mut self, _account: AccountId, _token_id: u64, _balance: u128) {}
     }
 
     #[cfg(test)]
@@ -1025,6 +1053,138 @@ mod fractional {
             assert_eq!(Fractional::isqrt(4), 2);
             assert_eq!(Fractional::isqrt(9), 3);
             assert_eq!(Fractional::isqrt(10_000), 100);
+        }
+
+        // ── Issue #493: Reentrancy guard tests ───────────────────────────────
+
+        /// Test that calling buy_shares while the guard is locked returns ReentrantCall.
+        /// We simulate this by manually locking the guard before the call.
+        #[ink::test]
+        fn test_reentrant_buy_shares_returns_error() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 100);
+            f.list_shares_for_sale(1, 50, 10).unwrap();
+
+            // Manually lock the guard to simulate a reentrant call
+            f.reentrancy_guard.enter().expect("first lock should succeed");
+
+            test::set_caller::<ink::env::DefaultEnvironment>(bob());
+            // While guard is locked, buy_shares should return ReentrantCall
+            let result = f.buy_shares(alice(), 1, 10);
+            assert_eq!(
+                result,
+                Err(FractionalError::ReentrantCall),
+                "buy_shares must return ReentrantCall when guard is locked (issue #493)"
+            );
+
+            // Unlock so the guard does not stay poisoned
+            f.reentrancy_guard.exit();
+        }
+
+        /// Test that calling swap_shares_for_value while the guard is locked returns ReentrantCall.
+        #[ink::test]
+        fn test_reentrant_swap_shares_for_value_returns_error() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(10_000);
+            f.add_liquidity(1, 100, 0).unwrap();
+
+            // Manually lock the guard to simulate a reentrant call
+            f.reentrancy_guard.enter().expect("first lock should succeed");
+
+            let result = f.swap_shares_for_value(1, 10, 0);
+            assert_eq!(
+                result,
+                Err(FractionalError::ReentrantCall),
+                "swap_shares_for_value must return ReentrantCall when guard is locked (issue #493)"
+            );
+
+            f.reentrancy_guard.exit();
+        }
+
+        /// Test that redeem_shares is guarded and returns ReentrantCall when locked.
+        #[ink::test]
+        fn test_reentrant_redeem_shares_returns_error() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 100);
+            f.set_last_price(1, 5);
+
+            f.reentrancy_guard.enter().expect("first lock should succeed");
+
+            let result = f.redeem_shares(1, 10);
+            assert_eq!(
+                result,
+                Err(FractionalError::ReentrantCall),
+                "redeem_shares must return ReentrantCall when guard is locked (issue #493)"
+            );
+
+            f.reentrancy_guard.exit();
+        }
+
+        /// Test that add_liquidity is guarded and returns ReentrantCall when locked.
+        #[ink::test]
+        fn test_reentrant_add_liquidity_returns_error() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            f.reentrancy_guard.enter().expect("first lock should succeed");
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(500);
+            let result = f.add_liquidity(1, 100, 0);
+            assert_eq!(
+                result,
+                Err(FractionalError::ReentrantCall),
+                "add_liquidity must return ReentrantCall when guard is locked (issue #493)"
+            );
+
+            f.reentrancy_guard.exit();
+        }
+
+        /// Test that remove_liquidity is guarded and returns ReentrantCall when locked.
+        #[ink::test]
+        fn test_reentrant_remove_liquidity_returns_error() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 1000);
+
+            test::set_value_transferred::<ink::env::DefaultEnvironment>(1000);
+            let lp = f.add_liquidity(1, 200, 0).unwrap();
+
+            f.reentrancy_guard.enter().expect("first lock should succeed");
+
+            let result = f.remove_liquidity(1, lp, 0, 0);
+            assert_eq!(
+                result,
+                Err(FractionalError::ReentrantCall),
+                "remove_liquidity must return ReentrantCall when guard is locked (issue #493)"
+            );
+
+            f.reentrancy_guard.exit();
+        }
+
+        /// Test that after a non-reentrant call completes, the guard is unlocked
+        /// and a subsequent call succeeds normally.
+        #[ink::test]
+        fn test_guard_releases_after_successful_call() {
+            let mut f = Fractional::new();
+            test::set_caller::<ink::env::DefaultEnvironment>(alice());
+            f.mint_shares(alice(), 1, 200);
+            f.set_last_price(1, 5);
+
+            // First call: guard enters and exits normally
+            let payout1 = f.redeem_shares(1, 50).unwrap();
+            assert_eq!(payout1, 250);
+
+            // Guard should be unlocked — second call must succeed
+            let payout2 = f.redeem_shares(1, 50).unwrap();
+            assert_eq!(payout2, 250);
+
+            assert!(!f.reentrancy_guard.is_locked(), "guard must be unlocked after call");
         }
     }
 }

--- a/contracts/insurance/src/types.rs
+++ b/contracts/insurance/src/types.rs
@@ -511,6 +511,16 @@ pub struct FraudDetectionStats {
     pub false_positive_count: u32,
     pub average_fraud_score: u32,
     pub last_update: u64,
+}
+
+/// Summary statistics for a reinsurance agreement.
+///
+/// Previously missing derives caused compile errors when this type was
+/// returned from an ink! message or stored in a Mapping (fixed bug — see #487).
+#[derive(
+    Debug, Clone, PartialEq, scale::Encode, scale::Decode, ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
 pub struct ReinsuranceStats {
     pub agreement_id: u64,
     pub treaty_type: ReinsuranceTreatyType,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -27,6 +27,13 @@ propchain-monitoring = { path = "../contracts/monitoring", default-features = fa
 tax-compliance = { path = "../contracts/tax-compliance", default-features = false }
 compliance_registry = { path = "../contracts/compliance_registry", default-features = false }
 
+# Issue #488 / #487 / #489: contract crates needed for new test modules
+fractional = { path = "../contracts/fractional", default-features = false }
+governance = { path = "../contracts/governance", default-features = false }
+staking = { path = "../contracts/staking", default-features = false }
+propchain-bridge = { path = "../contracts/bridge", default-features = false }
+propchain-insurance = { path = "../contracts/insurance", default-features = false }
+
 # Async runtime
 tokio = { version = "1.0", features = ["full"], optional = true }
 
@@ -55,6 +62,11 @@ std = [
     "propchain-monitoring/std",
     "tax-compliance/std",
     "compliance_registry/std",
+    "fractional/std",
+    "governance/std",
+    "staking/std",
+    "propchain-bridge/std",
+    "propchain-insurance/std",
     "serde/std",
     "serde_json/std",
     "tokio",

--- a/tests/bridge_chaos.rs
+++ b/tests/bridge_chaos.rs
@@ -1,0 +1,549 @@
+/// # Bridge Chaos Engineering Tests (Issue #489)
+///
+/// Simulates various failure modes to verify the bridge contract's resilience.
+///
+/// Acceptance criteria:
+///   ✓ Simulate validator key compromise (rapid failed signatures)
+///   ✓ Simulate oracle price manipulation attempts
+///   ✓ Simulate network partition (timeout / request-expiry handling)
+///   ✓ Simulate rapid pause/unpause cycles
+///   ✓ Simulate multiple concurrent recovery operations
+///   ✓ Verify bridge state remains consistent after chaos scenarios
+///   ✓ Verify no funds are lost or double-spent
+#[cfg(test)]
+mod bridge_chaos {
+    use bridge::bridge::{
+        BridgeOperationStatus, BridgeOperation, ChainTxStatus, Error, PauseFlags, PauseReason,
+        PropertyBridge,
+    };
+    use propchain_traits::PropertyMetadata;
+    use ink::env::{test, DefaultEnvironment};
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn alice() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().alice
+    }
+    fn bob() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().bob
+    }
+    fn charlie() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().charlie
+    }
+    fn django() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().django
+    }
+    fn eve() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().eve
+    }
+
+    fn setup_bridge() -> PropertyBridge {
+        test::set_caller::<DefaultEnvironment>(alice());
+        // supported_chains=[1,2,3], min_sigs=2, max_sigs=5, timeout=100, gas=500_000
+        PropertyBridge::new(vec![1, 2, 3], 2, 5, 100, 500_000)
+    }
+
+    fn make_metadata(label: &str) -> PropertyMetadata {
+        PropertyMetadata {
+            location: label.into(),
+            size: 1_000,
+            legal_description: label.into(),
+            valuation: 100_000,
+            documents_url: "ipfs://chaos-test".into(),
+        }
+    }
+
+    fn setup_bridge_with_validators() -> PropertyBridge {
+        let mut bridge = setup_bridge();
+        test::set_caller::<DefaultEnvironment>(alice());
+        bridge.add_validator(alice()).expect("add validator alice");
+        bridge.add_validator(bob()).expect("add validator bob");
+        bridge.add_validator(charlie()).expect("add validator charlie");
+        bridge
+    }
+
+    // ── Chaos Test 1: Validator key compromise (rapid failed signatures) ──────
+
+    /// Chaos scenario: a compromised validator sends a rapid burst of `approve=false`
+    /// signatures.  The bridge's suspicious-activity heuristic should detect this and
+    /// auto-pause the signing operation class, keeping funds safe.
+    ///
+    /// Even if the auto-pause threshold is not immediately crossed, the bridge must
+    /// at minimum prevent double-signing (AlreadySigned) and must never execute a
+    /// request that was explicitly rejected.
+    #[ink::test]
+    fn chaos_validator_key_compromise_rapid_failed_signatures() {
+        let mut bridge = setup_bridge_with_validators();
+
+        // Create several bridge requests so we can fire failed sigs across them
+        let mut request_ids = Vec::new();
+        for i in 0u64..5 {
+            test::set_caller::<DefaultEnvironment>(alice());
+            let rid = bridge
+                .initiate_bridge_multisig(
+                    i + 1,
+                    2,
+                    bob(),
+                    2,
+                    Some(200),
+                    make_metadata("compromise-test"),
+                )
+                .expect("initiate");
+            request_ids.push(rid);
+        }
+
+        // "Compromised" bob fires false-approvals on all requests
+        test::set_caller::<DefaultEnvironment>(bob());
+        for &rid in &request_ids {
+            let _ = bridge.sign_bridge_request(rid, false);
+        }
+
+        // Re-signing the same request must return AlreadySigned (no replay)
+        test::set_caller::<DefaultEnvironment>(bob());
+        let replay = bridge.sign_bridge_request(request_ids[0], false);
+        assert_eq!(
+            replay,
+            Err(Error::AlreadySigned),
+            "duplicate false signature must be rejected with AlreadySigned"
+        );
+
+        // Any request that received a false signature must be in Failed state
+        for &rid in &request_ids {
+            if let Some(info) = bridge.monitor_bridge_status(rid) {
+                // Requests signed false should be Failed or Pending (depending on
+                // whether the threshold was met by other validators in time)
+                assert_ne!(
+                    info.status,
+                    BridgeOperationStatus::Completed,
+                    "request {rid} must not be Completed after a false-signature attack"
+                );
+            }
+        }
+
+        // Verify bridge analytics are still coherent
+        let analytics = bridge.get_bridge_analytics();
+        assert!(
+            analytics.total_requests >= 5,
+            "analytics must reflect all created requests"
+        );
+    }
+
+    // ── Chaos Test 2: Oracle price manipulation attempt ───────────────────────
+
+    /// Chaos scenario: an attacker tries to manipulate the bridge fee by submitting
+    /// artificially large or tiny `amount_in` values to `register_cross_chain_trade`.
+    /// The bridge must apply rate-limiting and the fee quote must remain coherent.
+    #[ink::test]
+    fn chaos_oracle_price_manipulation_attempt() {
+        let mut bridge = setup_bridge();
+
+        // Attempt 1: absurdly large amount — fee quote must not overflow
+        test::set_caller::<DefaultEnvironment>(alice());
+        let result_large = bridge.quote_cross_chain_trade(2, u128::MAX / 2);
+        if let Ok(quote) = result_large {
+            // protocol_fee = amount / 200 → must not be zero for large amounts
+            assert!(
+                quote.total_fee >= quote.protocol_fee,
+                "total_fee must be >= protocol_fee (no negative fee)"
+            );
+            // total_fee must not exceed the amount itself
+            assert!(
+                quote.total_fee < u128::MAX / 2,
+                "total_fee must not overflow"
+            );
+        }
+
+        // Attempt 2: zero amount — fee must be zero
+        let result_zero = bridge.quote_cross_chain_trade(2, 0);
+        if let Ok(quote) = result_zero {
+            assert_eq!(quote.protocol_fee, 0, "zero-amount protocol fee must be 0");
+        }
+
+        // Attempt 3: try to register a trade with a very large amount_in that might
+        // trip the hourly volume limit.  The bridge must either accept or return a
+        // domain error — it must not panic.
+        let result_register = bridge.register_cross_chain_trade(
+            1, None, 2, bob(), u128::MAX / 4, 0,
+        );
+        // Either Ok or a recognised error — never a panic
+        match result_register {
+            Ok(_) | Err(Error::RateLimitExceeded) | Err(Error::OperationPaused) => {}
+            Err(other) => panic!("unexpected error for large amount_in: {:?}", other),
+        }
+
+        // Verify bridge is still operational for normal amounts after the chaos
+        let normal_result = bridge.register_cross_chain_trade(1, None, 2, bob(), 1_000, 900);
+        // May succeed or hit rate limit — the key is no panic and no unexpected error
+        match normal_result {
+            Ok(_) | Err(Error::RateLimitExceeded) | Err(Error::OperationPaused) => {}
+            Err(other) => panic!("unexpected error for normal amount: {:?}", other),
+        }
+    }
+
+    // ── Chaos Test 3: Network partition (timeout / expiry handling) ───────────
+
+    /// Chaos scenario: a bridge request is created but the validators don't sign
+    /// it before its expiry block.  The bridge must mark it Expired and prevent
+    /// late execution.
+    #[ink::test]
+    fn chaos_network_partition_timeout_handling() {
+        let mut bridge = setup_bridge_with_validators();
+
+        // Create a request with a 1-block timeout — it will expire immediately
+        test::set_caller::<DefaultEnvironment>(alice());
+        let request_id = bridge
+            .initiate_bridge_multisig(1, 2, bob(), 2, Some(1), make_metadata("timeout-test"))
+            .expect("initiate");
+
+        // Advance blocks past the expiry
+        test::advance_block::<DefaultEnvironment>();
+        test::advance_block::<DefaultEnvironment>();
+
+        // Signing an expired request must return RequestExpired
+        test::set_caller::<DefaultEnvironment>(bob());
+        let sign_result = bridge.sign_bridge_request(request_id, true);
+        assert_eq!(
+            sign_result,
+            Err(Error::RequestExpired),
+            "signing an expired request must return RequestExpired"
+        );
+
+        // Execution must also fail
+        test::set_caller::<DefaultEnvironment>(alice());
+        let exec_result = bridge.execute_bridge(request_id);
+        assert!(
+            exec_result.is_err(),
+            "executing an expired request must fail"
+        );
+
+        // Admin can roll back the timed-out request
+        let rollback_result =
+            bridge.rollback_bridge_transaction(request_id, "timeout rollback".into());
+        assert!(
+            rollback_result.is_ok(),
+            "admin must be able to roll back a timed-out request"
+        );
+
+        // After rollback both chain legs must be Failed
+        let status = bridge
+            .get_cross_chain_tx_status(request_id)
+            .expect("status should exist");
+        assert_eq!(
+            status.source_status.status,
+            ChainTxStatus::Failed,
+            "source leg must be Failed after rollback"
+        );
+        assert_eq!(
+            status.destination_status.status,
+            ChainTxStatus::Failed,
+            "destination leg must be Failed after rollback"
+        );
+    }
+
+    // ── Chaos Test 4: Rapid pause / unpause cycles ────────────────────────────
+
+    /// Chaos scenario: an attacker with guardian access (or a buggy guardian)
+    /// rapidly toggles pause on and off.  The bridge must remain in a consistent
+    /// state after the storm.
+    #[ink::test]
+    fn chaos_rapid_pause_unpause_cycles() {
+        let mut bridge = setup_bridge();
+
+        // Register alice as a guardian
+        test::set_caller::<DefaultEnvironment>(alice());
+        bridge.add_guardian(alice()).expect("add guardian");
+
+        // Rapid pause / unpause — 20 cycles
+        for i in 0..20u32 {
+            test::set_caller::<DefaultEnvironment>(alice());
+            if i % 2 == 0 {
+                bridge
+                    .emergency_pause(
+                        PauseFlags {
+                            all_operations: true,
+                            new_requests: true,
+                            signing: true,
+                            execution: true,
+                            cross_chain_trades: true,
+                        },
+                        PauseReason::GuardianTrigger,
+                        Some(format!("chaos cycle {}", i)),
+                    )
+                    .expect("pause should succeed");
+            } else {
+                bridge
+                    .emergency_unpause(PauseFlags {
+                        all_operations: true,
+                        new_requests: true,
+                        signing: true,
+                        execution: true,
+                        cross_chain_trades: true,
+                    })
+                    .expect("unpause should succeed");
+            }
+        }
+
+        // After 20 cycles (last is unpause at cycle 19 = odd → unpause),
+        // the bridge should be fully unpaused.
+        let health = bridge.get_bridge_health_status();
+        assert!(
+            !health.is_paused,
+            "bridge must be unpaused after even number of cycles ending on unpause"
+        );
+
+        // Operations must work normally after chaos
+        test::set_caller::<DefaultEnvironment>(alice());
+        let result = bridge.initiate_bridge_multisig(
+            1,
+            2,
+            bob(),
+            2,
+            Some(100),
+            make_metadata("post-chaos"),
+        );
+        assert!(
+            result.is_ok(),
+            "bridge should accept new requests after all pauses are cleared"
+        );
+
+        // Audit log must be non-empty and bounded
+        let audit = bridge.get_pause_audit_log();
+        assert!(
+            !audit.is_empty(),
+            "audit log must contain entries from the chaos cycles"
+        );
+        assert!(
+            audit.len() <= 256,
+            "audit log must be bounded to PAUSE_AUDIT_LOG_LIMIT"
+        );
+    }
+
+    // ── Chaos Test 5: Multiple concurrent recovery operations ─────────────────
+
+    /// Chaos scenario: admin attempts to run multiple recovery / rollback operations
+    /// simultaneously on different failed requests.  Each rollback must be isolated
+    /// and must not affect other requests.
+    #[ink::test]
+    fn chaos_multiple_concurrent_recovery_operations() {
+        let mut bridge = setup_bridge_with_validators();
+
+        // Create several requests
+        test::set_caller::<DefaultEnvironment>(alice());
+        let mut request_ids = Vec::new();
+        for i in 1u64..=5 {
+            let rid = bridge
+                .initiate_bridge_multisig(
+                    i,
+                    2,
+                    bob(),
+                    2,
+                    Some(50),
+                    make_metadata("concurrent-recovery"),
+                )
+                .expect("initiate");
+            request_ids.push(rid);
+        }
+
+        // Fail the first three by having a validator sign false
+        test::set_caller::<DefaultEnvironment>(bob());
+        for &rid in &request_ids[..3] {
+            let _ = bridge.sign_bridge_request(rid, false);
+        }
+
+        // Admin rolls back all five (some are failed, some are still pending)
+        test::set_caller::<DefaultEnvironment>(alice());
+        for &rid in &request_ids {
+            let result =
+                bridge.rollback_bridge_transaction(rid, format!("concurrent rollback {}", rid));
+            assert!(
+                result.is_ok(),
+                "admin must be able to rollback request {rid}"
+            );
+        }
+
+        // Verify all are in terminal Failed state
+        for &rid in &request_ids {
+            let info = bridge
+                .monitor_bridge_status(rid)
+                .expect("monitor must return info");
+            assert_eq!(
+                info.status,
+                BridgeOperationStatus::Failed,
+                "request {rid} must be in Failed state after rollback"
+            );
+        }
+
+        // Verify cross-chain trackers are all Failed
+        for &rid in &request_ids {
+            let status = bridge
+                .get_cross_chain_tx_status(rid)
+                .expect("cross-chain status must exist");
+            assert_eq!(
+                status.overall_status,
+                BridgeOperationStatus::Failed,
+                "cross-chain status for {rid} must be Failed"
+            );
+        }
+
+        // Analytics must be coherent after all rollbacks
+        let analytics = bridge.get_bridge_analytics();
+        assert_eq!(
+            analytics.total_requests, 5,
+            "analytics must count all 5 created requests"
+        );
+    }
+
+    // ── Chaos Test 6: Bridge state consistency after chaos ────────────────────
+
+    /// Verifies that after a mix of chaos actions the bridge counter and
+    /// request states remain self-consistent.
+    #[ink::test]
+    fn chaos_bridge_state_remains_consistent() {
+        let mut bridge = setup_bridge_with_validators();
+
+        test::set_caller::<DefaultEnvironment>(alice());
+
+        // Create 3 requests
+        let r1 = bridge
+            .initiate_bridge_multisig(1, 2, bob(), 2, Some(200), make_metadata("r1"))
+            .expect("r1");
+        let r2 = bridge
+            .initiate_bridge_multisig(2, 2, charlie(), 2, Some(200), make_metadata("r2"))
+            .expect("r2");
+        let r3 = bridge
+            .initiate_bridge_multisig(3, 2, django(), 2, Some(200), make_metadata("r3"))
+            .expect("r3");
+
+        // r1: fully approved and executed
+        bridge.add_validator(alice()).ok(); // may already be registered
+        test::set_caller::<DefaultEnvironment>(alice());
+        let _ = bridge.sign_bridge_request(r1, true);
+        test::set_caller::<DefaultEnvironment>(bob());
+        let _ = bridge.sign_bridge_request(r1, true);
+        test::set_caller::<DefaultEnvironment>(alice());
+        bridge.execute_bridge(r1).expect("execute r1");
+
+        // r2: failed via false signature
+        test::set_caller::<DefaultEnvironment>(charlie());
+        let _ = bridge.sign_bridge_request(r2, false);
+
+        // r3: rolled back by admin
+        test::set_caller::<DefaultEnvironment>(alice());
+        bridge
+            .rollback_bridge_transaction(r3, "state consistency test".into())
+            .expect("rollback r3");
+
+        // Verify each request's final state
+        let info_r1 = bridge.monitor_bridge_status(r1).expect("r1 info");
+        assert_eq!(
+            info_r1.status,
+            BridgeOperationStatus::Completed,
+            "r1 must be Completed"
+        );
+
+        let info_r2 = bridge.monitor_bridge_status(r2).expect("r2 info");
+        assert_eq!(
+            info_r2.status,
+            BridgeOperationStatus::Failed,
+            "r2 must be Failed"
+        );
+
+        let info_r3 = bridge.monitor_bridge_status(r3).expect("r3 info");
+        assert_eq!(
+            info_r3.status,
+            BridgeOperationStatus::Failed,
+            "r3 must be Failed"
+        );
+
+        // Analytics: 3 requests, 1 transaction completed
+        let analytics = bridge.get_bridge_analytics();
+        assert_eq!(analytics.total_requests, 3);
+        assert_eq!(analytics.total_transactions, 1, "only r1 should be a completed transaction");
+    }
+
+    // ── Chaos Test 7: No funds double-spent ──────────────────────────────────
+
+    /// Verifies the idempotency invariant: calling execute_bridge twice on the
+    /// same request must fail on the second call.
+    #[ink::test]
+    fn chaos_no_funds_double_spent() {
+        let mut bridge = setup_bridge_with_validators();
+
+        test::set_caller::<DefaultEnvironment>(alice());
+        let request_id = bridge
+            .initiate_bridge_multisig(1, 2, bob(), 2, None, make_metadata("double-spend-test"))
+            .expect("initiate");
+
+        // Collect 2 valid signatures
+        test::set_caller::<DefaultEnvironment>(alice());
+        bridge.sign_bridge_request(request_id, true).expect("alice sign");
+        test::set_caller::<DefaultEnvironment>(bob());
+        bridge.sign_bridge_request(request_id, true).expect("bob sign");
+
+        // First execution must succeed
+        test::set_caller::<DefaultEnvironment>(alice());
+        let first = bridge.execute_bridge(request_id);
+        assert!(first.is_ok(), "first execution must succeed");
+
+        // Second execution must fail (idempotency)
+        let second = bridge.execute_bridge(request_id);
+        assert!(
+            second.is_err(),
+            "second execution of the same request must fail (no double-spend)"
+        );
+
+        // Transaction counter must reflect only one execution
+        let analytics = bridge.get_bridge_analytics();
+        assert_eq!(
+            analytics.total_transactions, 1,
+            "only one transaction must be recorded (no double-spend)"
+        );
+    }
+
+    // ── Chaos Test 8: Pause blocks new requests but not status queries ────────
+
+    /// When the bridge is paused, new request creation must be blocked, but
+    /// read-only operations (monitor, get_config) must still work.
+    #[ink::test]
+    fn chaos_pause_blocks_writes_but_not_reads() {
+        let mut bridge = setup_bridge_with_validators();
+
+        // Create a request before the pause
+        test::set_caller::<DefaultEnvironment>(alice());
+        let rid = bridge
+            .initiate_bridge_multisig(1, 2, bob(), 2, Some(200), make_metadata("pre-pause"))
+            .expect("pre-pause request");
+
+        // Pause the bridge
+        bridge
+            .set_emergency_pause(true)
+            .expect("admin can pause");
+
+        // New requests must be blocked
+        let result = bridge
+            .initiate_bridge_multisig(2, 2, charlie(), 2, Some(200), make_metadata("post-pause"));
+        assert_eq!(
+            result,
+            Err(Error::OperationPaused),
+            "new requests must be blocked while paused"
+        );
+
+        // Read-only queries must still work
+        let info = bridge.monitor_bridge_status(rid);
+        assert!(
+            info.is_some(),
+            "monitor_bridge_status must work while paused"
+        );
+        let _ = bridge.get_config();
+        let _ = bridge.get_bridge_health_status();
+
+        // Unpause and verify operations resume
+        bridge.set_emergency_pause(false).expect("admin can unpause");
+        let post_unpause = bridge
+            .initiate_bridge_multisig(2, 2, charlie(), 2, Some(200), make_metadata("post-unpause"));
+        assert!(
+            post_unpause.is_ok(),
+            "new requests must be allowed after unpause"
+        );
+    }
+}

--- a/tests/integration_governance_staking.rs
+++ b/tests/integration_governance_staking.rs
@@ -1,0 +1,369 @@
+/// # Integration Tests: Governance ↔ Staking Interaction (Issue #488)
+///
+/// These tests verify the voting-power delegation pipeline between the
+/// Staking and Governance contracts.  Because ink! unit tests run inside a
+/// single contract environment we test both contracts directly rather than
+/// through cross-contract calls, which mirrors the actual interaction semantics.
+///
+/// Acceptance criteria tested:
+///   ✓ Staking creates governance power correctly
+///   ✓ Delegation transfers governance power to delegate
+///   ✓ Unstaking removes governance power
+///   ✓ Governance proposal creation requires minimum voting power
+///   ✓ Voting weight matches staked amount (including delegation)
+///   ✓ Multiple stakers vote on same proposal with correct weights
+#[cfg(test)]
+mod integration_governance_staking {
+    // ── Staking contract ─────────────────────────────────────────────────────
+    use staking::staking::{Error as StakingError, LockPeriod, Staking};
+
+    // ── Governance contract ───────────────────────────────────────────────────
+    use governance::governance::{
+        Error as GovernanceError, GovernanceAction, GovernanceProposal, Governance,
+    };
+
+    use ink::env::{test, DefaultEnvironment};
+    use ink::primitives::Hash;
+
+    // ── Account helpers ───────────────────────────────────────────────────────
+
+    fn alice() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().alice
+    }
+    fn bob() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().bob
+    }
+    fn charlie() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().charlie
+    }
+    fn django() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().django
+    }
+
+    /// Convenience: construct a Staking contract with sensible defaults.
+    fn new_staking() -> Staking {
+        test::set_caller::<DefaultEnvironment>(alice());
+        // reward_rate_bps = 500 (5%), min_stake = 1_000
+        Staking::new(500, 1_000)
+    }
+
+    /// Convenience: construct a Governance contract where alice, bob, charlie
+    /// are signers and the threshold is 2 out of 3.
+    fn new_governance() -> Governance {
+        test::set_caller::<DefaultEnvironment>(alice());
+        Governance::new(vec![alice(), bob(), charlie()], 2, 0)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: Staking creates governance power correctly
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Stakes tokens and verifies that governance power equals the staked amount.
+    #[ink::test]
+    fn test_staking_creates_governance_power() {
+        let mut staking = new_staking();
+        test::set_caller::<DefaultEnvironment>(alice());
+
+        let stake_amount: u128 = 10_000;
+        staking.stake(stake_amount, LockPeriod::Flexible).expect("stake should succeed");
+
+        // Governance power must equal staked amount immediately after staking
+        let power = staking.get_governance_power(alice());
+        assert_eq!(
+            power, stake_amount,
+            "governance power must equal staked amount after staking"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: Delegation transfers governance power to delegate
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// After delegating, the delegate receives the staker's governance power
+    /// and the staker no longer holds it directly.
+    #[ink::test]
+    fn test_delegation_transfers_governance_power() {
+        let mut staking = new_staking();
+        let stake_amount: u128 = 20_000;
+
+        // Alice stakes
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking.stake(stake_amount, LockPeriod::Flexible).expect("alice stake");
+
+        // Alice delegates governance to bob
+        staking
+            .delegate_governance(bob())
+            .expect("delegation should succeed");
+
+        // Bob should now hold alice's governance power
+        let bob_power = staking.get_governance_power(bob());
+        assert_eq!(
+            bob_power, stake_amount,
+            "bob should hold alice's governance power after delegation"
+        );
+
+        // Alice's own governance power slot should be zero (power moved to bob)
+        let alice_power = staking.get_governance_power(alice());
+        assert_eq!(
+            alice_power, 0,
+            "alice's direct governance power should be zero after delegating"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: Unstaking removes governance power
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// After unstaking, governance power drops back to zero.
+    #[ink::test]
+    fn test_unstaking_removes_governance_power() {
+        let mut staking = new_staking();
+
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking
+            .stake(15_000, LockPeriod::Flexible)
+            .expect("alice stake");
+
+        // Verify power present
+        assert_eq!(staking.get_governance_power(alice()), 15_000);
+
+        // Unstake (flexible lock, no penalty)
+        staking.unstake().expect("unstake should succeed");
+
+        // Governance power must be zero after unstaking
+        let power_after = staking.get_governance_power(alice());
+        assert_eq!(
+            power_after, 0,
+            "governance power must be zero after unstaking"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4: Governance proposal creation requires minimum voting power
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Only stakers (who hold governance power) can create parameter proposals.
+    /// Non-stakers are rejected with NoVotingPower.
+    #[ink::test]
+    fn test_proposal_creation_requires_voting_power() {
+        let mut staking = new_staking();
+
+        // Django has no stake → proposal creation must fail
+        test::set_caller::<DefaultEnvironment>(django());
+        let result = staking.propose_param_change(staking::staking::ParamKind::MinStake(2_000));
+        assert_eq!(
+            result,
+            Err(StakingError::NoVotingPower),
+            "non-staker must not be able to create a proposal"
+        );
+
+        // Alice stakes and can now create a proposal
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking
+            .stake(5_000, LockPeriod::Flexible)
+            .expect("alice stake");
+
+        let proposal_id = staking
+            .propose_param_change(staking::staking::ParamKind::MinStake(2_000))
+            .expect("staker should be able to create a proposal");
+
+        let proposal = staking
+            .get_param_proposal(proposal_id)
+            .expect("proposal should exist");
+        assert_eq!(proposal.id, proposal_id);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 5: Voting weight matches staked amount (including delegation)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Voting weight equals the staked amount.  When alice delegates to bob,
+    /// bob's effective voting weight equals both stakes combined.
+    #[ink::test]
+    fn test_voting_weight_matches_staked_amount_with_delegation() {
+        let mut staking = new_staking();
+
+        let alice_stake: u128 = 10_000;
+        let bob_stake: u128 = 5_000;
+
+        // Alice stakes and delegates to bob
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking.stake(alice_stake, LockPeriod::Flexible).expect("alice stake");
+        staking.delegate_governance(bob()).expect("alice delegates to bob");
+
+        // Bob stakes (creating his own power)
+        test::set_caller::<DefaultEnvironment>(bob());
+        staking.stake(bob_stake, LockPeriod::Flexible).expect("bob stake");
+
+        // Bob's governance power = his own stake + alice's delegated power
+        let bob_power = staking.get_governance_power(bob());
+        assert_eq!(
+            bob_power,
+            alice_stake + bob_stake,
+            "bob's governance power should equal his stake plus alice's delegated stake"
+        );
+
+        // Alice's own governance power slot is zero (she delegated)
+        let alice_power = staking.get_governance_power(alice());
+        assert_eq!(alice_power, 0);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 6: Multiple stakers vote on same proposal with correct weights
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Three stakers with different amounts vote on the same proposal.
+    /// votes_for and votes_against reflect the total staked weight.
+    #[ink::test]
+    fn test_multiple_stakers_vote_with_correct_weights() {
+        let mut staking = new_staking();
+
+        let alice_stake: u128 = 30_000;
+        let bob_stake: u128 = 20_000;
+        let charlie_stake: u128 = 10_000;
+
+        // Fund the reward pool so staking.stake doesn't panic later on rewards
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking.fund_reward_pool(100_000).expect("fund pool");
+
+        // All three stake
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking.stake(alice_stake, LockPeriod::Flexible).expect("alice stake");
+
+        test::set_caller::<DefaultEnvironment>(bob());
+        staking.stake(bob_stake, LockPeriod::Flexible).expect("bob stake");
+
+        test::set_caller::<DefaultEnvironment>(charlie());
+        staking.stake(charlie_stake, LockPeriod::Flexible).expect("charlie stake");
+
+        // Alice creates a proposal
+        test::set_caller::<DefaultEnvironment>(alice());
+        let proposal_id = staking
+            .propose_param_change(staking::staking::ParamKind::MinStake(2_000))
+            .expect("alice creates proposal");
+
+        // Alice and Bob vote FOR, Charlie votes AGAINST
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking
+            .vote_on_proposal(proposal_id, true)
+            .expect("alice votes for");
+
+        test::set_caller::<DefaultEnvironment>(bob());
+        staking
+            .vote_on_proposal(proposal_id, true)
+            .expect("bob votes for");
+
+        test::set_caller::<DefaultEnvironment>(charlie());
+        staking
+            .vote_on_proposal(proposal_id, false)
+            .expect("charlie votes against");
+
+        // Check accumulated vote weights
+        let proposal = staking
+            .get_param_proposal(proposal_id)
+            .expect("proposal should exist");
+
+        assert_eq!(
+            proposal.votes_for,
+            alice_stake + bob_stake,
+            "votes_for should equal alice + bob stake"
+        );
+        assert_eq!(
+            proposal.votes_against,
+            charlie_stake,
+            "votes_against should equal charlie's stake"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 7: Governance signers can create and vote on proposals (Governance contract)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// Verify the Governance contract's proposal lifecycle integrates with
+    /// the expected voting-power model (signer-based, not stake-based).
+    #[ink::test]
+    fn test_governance_proposal_lifecycle() {
+        let mut gov = new_governance();
+
+        // Alice creates a proposal
+        test::set_caller::<DefaultEnvironment>(alice());
+        let proposal_id = gov
+            .create_proposal(
+                Hash::from([1u8; 32]),
+                GovernanceAction::ModifyProperty,
+                None,
+            )
+            .expect("alice should be able to create a proposal as a signer");
+
+        // Bob votes for
+        test::set_caller::<DefaultEnvironment>(bob());
+        gov.vote(proposal_id, true).expect("bob votes for");
+
+        // After bob's vote the threshold (2) is met → proposal moves to Approved
+        let proposal: GovernanceProposal = gov
+            .get_proposal(proposal_id)
+            .expect("proposal should exist");
+
+        use governance::governance::ProposalStatus;
+        assert_eq!(
+            proposal.status,
+            ProposalStatus::Approved,
+            "proposal should be Approved after threshold votes"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 8: Non-signer cannot create governance proposals
+    // ─────────────────────────────────────────────────────────────────────────
+
+    #[ink::test]
+    fn test_non_signer_cannot_create_governance_proposal() {
+        let mut gov = new_governance();
+
+        // Django is not a signer
+        test::set_caller::<DefaultEnvironment>(django());
+        let result = gov.create_proposal(
+            Hash::from([2u8; 32]),
+            GovernanceAction::SaleApproval,
+            None,
+        );
+        assert_eq!(
+            result,
+            Err(GovernanceError::NotASigner),
+            "non-signer must not create governance proposals"
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 9: Delegation and then re-delegation updates power correctly
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// When alice delegates to bob and then delegates again to charlie,
+    /// charlie ends up with alice's power and bob's power is removed.
+    #[ink::test]
+    fn test_re_delegation_updates_governance_power() {
+        let mut staking = new_staking();
+        let stake_amount: u128 = 10_000;
+
+        test::set_caller::<DefaultEnvironment>(alice());
+        staking.stake(stake_amount, LockPeriod::Flexible).expect("alice stake");
+
+        // First delegation: alice → bob
+        staking.delegate_governance(bob()).expect("first delegation");
+        assert_eq!(staking.get_governance_power(bob()), stake_amount);
+        assert_eq!(staking.get_governance_power(alice()), 0);
+
+        // Re-delegation: alice → charlie
+        staking.delegate_governance(charlie()).expect("second delegation");
+        assert_eq!(
+            staking.get_governance_power(charlie()),
+            stake_amount,
+            "charlie should hold alice's power after re-delegation"
+        );
+        assert_eq!(
+            staking.get_governance_power(bob()),
+            0,
+            "bob's power should be cleared after alice re-delegates"
+        );
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -22,3 +22,15 @@ pub mod security_bridge_tests;
 pub mod security_compliance_tests;
 pub mod security_fuzzing_tests;
 pub mod security_overflow_tests;
+
+// ── Integration Test Modules ─────────────────────────────────────────────
+/// Issue #488: Cross-contract integration tests for governance ↔ staking
+pub mod integration_governance_staking;
+
+// ── Bridge Chaos Engineering Tests ───────────────────────────────────────
+/// Issue #489: Chaos engineering tests for bridge failure scenarios
+pub mod bridge_chaos;
+
+// ── Regression Test Suite ─────────────────────────────────────────────────
+/// Issue #487: Regression test suite for all previously fixed bugs
+pub mod regression;

--- a/tests/regression/closed_bugs.rs
+++ b/tests/regression/closed_bugs.rs
@@ -1,0 +1,175 @@
+/// # Regression: Closed bug reports (Issue #487)
+///
+/// Each test maps to a specific closed issue.  The test name includes the
+/// issue number so CI output pinpoints exactly which regression fired.
+#[cfg(test)]
+mod closed_bugs_regression {
+
+    use ink::env::{test, DefaultEnvironment};
+
+    fn alice() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().alice
+    }
+    fn bob() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().bob
+    }
+
+    // ── Fractional — issue #493: ReentrantCall variant exists ────────────────
+
+    /// Regression for issue #493: FractionalError must contain a ReentrantCall
+    /// variant so callers can match on the specific error type.
+    #[test]
+    fn fractional_error_has_reentrant_call_variant() {
+        use fractional::fractional::FractionalError;
+
+        let err = FractionalError::ReentrantCall;
+        // Pattern match ensures the variant compiles
+        match err {
+            FractionalError::ReentrantCall => {} // expected
+            _ => panic!("expected ReentrantCall variant"),
+        }
+    }
+
+    // ── Fractional — issue #493: From<ReentrancyError> for FractionalError ───
+
+    /// Regression: FractionalError must implement From<ReentrancyError> so the
+    /// `?` operator inside non_reentrant! works without a manual .map_err call.
+    #[test]
+    fn fractional_error_from_reentrancy_error() {
+        use fractional::fractional::FractionalError;
+        use propchain_traits::ReentrancyError;
+
+        let source = ReentrancyError::ReentrantCall;
+        let converted = FractionalError::from(source);
+        assert_eq!(
+            converted,
+            FractionalError::ReentrantCall,
+            "From<ReentrancyError> must map to FractionalError::ReentrantCall"
+        );
+    }
+
+    // ── Fractional — issue #493: guard is in storage ─────────────────────────
+
+    /// Regression: Fractional storage must contain a ReentrancyGuard field so
+    /// the guard state persists across calls (not per-call stack variable).
+    #[ink::test]
+    fn fractional_storage_contains_reentrancy_guard() {
+        use fractional::fractional::Fractional;
+
+        let f = Fractional::new();
+        // The guard field is accessible and starts unlocked
+        assert!(
+            !f.reentrancy_guard.is_locked(),
+            "guard must start unlocked on construction"
+        );
+    }
+
+    // ── AMM pool — existing invariant: x*y=k ────────────────────────────────
+
+    /// Regression: AMM pool must maintain the constant-product invariant.
+    /// A swap must not violate k = share_reserve * value_reserve (allowing for
+    /// the 0.3% fee that slightly increases k).
+    #[ink::test]
+    fn amm_constant_product_invariant_maintained_after_swap() {
+        use fractional::fractional::Fractional;
+
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 1000);
+
+        test::set_value_transferred::<DefaultEnvironment>(10_000);
+        f.add_liquidity(1, 100, 0).unwrap();
+
+        let pool_before = f.get_pool(1).unwrap();
+        let k_before = pool_before.share_reserve * pool_before.value_reserve;
+
+        // Swap 10 shares
+        let value_out = f.swap_shares_for_value(1, 10, 0).unwrap();
+        assert!(value_out > 0);
+
+        let pool_after = f.get_pool(1).unwrap();
+        let k_after = pool_after.share_reserve * pool_after.value_reserve;
+
+        // k should be equal to or slightly higher than before (fee stays in pool)
+        assert!(
+            k_after >= k_before,
+            "AMM k must not decrease after a swap (fee stays in pool)"
+        );
+    }
+
+    // ── Staking — minimum stake enforced ────────────────────────────────────
+
+    /// Regression: staking below minimum should return InsufficientAmount.
+    #[ink::test]
+    fn staking_minimum_stake_enforced() {
+        use staking::staking::{Error as StakingError, LockPeriod, Staking};
+
+        let mut s = Staking::new(500, 10_000); // min_stake = 10_000
+        test::set_caller::<DefaultEnvironment>(alice());
+
+        let result = s.stake(9_999, LockPeriod::Flexible);
+        assert_eq!(
+            result,
+            Err(StakingError::InsufficientAmount),
+            "staking below minimum must return InsufficientAmount"
+        );
+    }
+
+    // ── Staking — double-stake prevented ────────────────────────────────────
+
+    /// Regression: a second stake from the same account must return AlreadyStaked.
+    #[ink::test]
+    fn staking_double_stake_prevented() {
+        use staking::staking::{Error as StakingError, LockPeriod, Staking};
+
+        let mut s = Staking::new(500, 1_000);
+        test::set_caller::<DefaultEnvironment>(alice());
+
+        s.stake(5_000, LockPeriod::Flexible).expect("first stake");
+        let result = s.stake(5_000, LockPeriod::Flexible);
+        assert_eq!(
+            result,
+            Err(StakingError::AlreadyStaked),
+            "second stake from same account must return AlreadyStaked"
+        );
+    }
+
+    // ── Governance — threshold enforced ─────────────────────────────────────
+
+    /// Regression: proposal execution before threshold is reached must fail.
+    #[ink::test]
+    fn governance_threshold_enforced_before_execution() {
+        use governance::governance::{
+            Error as GovError, GovernanceAction, GovernanceProposal, Governance,
+        };
+        use ink::primitives::Hash;
+
+        test::set_caller::<DefaultEnvironment>(alice());
+        let mut gov = Governance::new(vec![alice(), bob()], 2, 0);
+
+        let pid = gov
+            .create_proposal(Hash::from([1u8; 32]), GovernanceAction::ModifyProperty, None)
+            .expect("create proposal");
+
+        // Only one vote (alice) — threshold is 2
+        test::set_caller::<DefaultEnvironment>(alice());
+        gov.vote(pid, true).expect("alice votes");
+
+        // Proposal should NOT be approved yet
+        let proposal: GovernanceProposal = gov.get_proposal(pid).expect("get proposal");
+        use governance::governance::ProposalStatus;
+        assert_ne!(
+            proposal.status,
+            ProposalStatus::Approved,
+            "proposal must not be approved with only 1/2 votes"
+        );
+
+        // Execute must fail because status is still Active
+        let result = gov.execute_proposal(pid);
+        assert_eq!(
+            result,
+            Err(GovError::ProposalClosed),
+            "execute_proposal on non-Approved proposal must return ProposalClosed"
+        );
+    }
+}

--- a/tests/regression/mod.rs
+++ b/tests/regression/mod.rs
@@ -1,0 +1,13 @@
+/// # Regression Test Suite (Issue #487)
+///
+/// Each test in this suite references the closed bug it guards against.
+/// When a bug is reopened the failing test pinpoints the exact regression.
+///
+/// Modules:
+///   - `reinsurance_stats_derives` — encodes/decodes ReinsuranceStats (fixed in earlier work)
+///   - `reentrancy_guard`         — verifies the guard on each protected function
+///   - `closed_bugs`              — miscellaneous one-off regressions
+
+pub mod closed_bugs;
+pub mod reentrancy_guard;
+pub mod reinsurance_stats_derives;

--- a/tests/regression/reentrancy_guard.rs
+++ b/tests/regression/reentrancy_guard.rs
@@ -1,0 +1,180 @@
+/// # Regression: Reentrancy guard on each protected function (Issue #487)
+///
+/// Bug references:
+///   - Issue #493 — fractional contract functions lacked reentrancy protection
+///   - Staking contract unstake/claim_rewards lacked guard initially
+///   - Bridge execute_bridge lacked guard initially
+///
+/// Each test locks the guard manually (simulating a re-entrant context) and
+/// verifies the guarded function returns the appropriate error rather than
+/// proceeding with the operation.
+#[cfg(test)]
+mod reentrancy_guard_regression {
+
+    // ── Fractional contract ───────────────────────────────────────────────────
+    use fractional::fractional::{Fractional, FractionalError};
+
+    use ink::env::{test, DefaultEnvironment};
+
+    fn alice() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().alice
+    }
+    fn bob() -> ink::primitives::AccountId {
+        test::default_accounts::<DefaultEnvironment>().bob
+    }
+
+    // ── Issue #493: Fractional — buy_shares ─────────────────────────────────
+
+    /// Regression for issue #493: buy_shares must return ReentrantCall when
+    /// the reentrancy guard is already locked.
+    #[ink::test]
+    fn fractional_buy_shares_reentrant_call_regression() {
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 100);
+        f.list_shares_for_sale(1, 50, 10).unwrap();
+
+        // Simulate reentrancy by locking the guard externally
+        f.reentrancy_guard.enter().expect("guard enter");
+
+        test::set_caller::<DefaultEnvironment>(bob());
+        let result = f.buy_shares(alice(), 1, 10);
+        assert_eq!(
+            result,
+            Err(FractionalError::ReentrantCall),
+            "[regression #493] buy_shares must return ReentrantCall"
+        );
+        f.reentrancy_guard.exit();
+    }
+
+    // ── Issue #493: Fractional — redeem_shares ──────────────────────────────
+
+    /// Regression for issue #493: redeem_shares must return ReentrantCall when
+    /// the reentrancy guard is already locked.
+    #[ink::test]
+    fn fractional_redeem_shares_reentrant_call_regression() {
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 100);
+        f.set_last_price(1, 5);
+
+        f.reentrancy_guard.enter().expect("guard enter");
+        let result = f.redeem_shares(1, 10);
+        assert_eq!(
+            result,
+            Err(FractionalError::ReentrantCall),
+            "[regression #493] redeem_shares must return ReentrantCall"
+        );
+        f.reentrancy_guard.exit();
+    }
+
+    // ── Issue #493: Fractional — swap_shares_for_value ──────────────────────
+
+    /// Regression for issue #493: swap_shares_for_value must return ReentrantCall
+    /// when the reentrancy guard is already locked.
+    #[ink::test]
+    fn fractional_swap_shares_for_value_reentrant_call_regression() {
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 1000);
+
+        test::set_value_transferred::<DefaultEnvironment>(10_000);
+        f.add_liquidity(1, 100, 0).unwrap();
+
+        f.reentrancy_guard.enter().expect("guard enter");
+        let result = f.swap_shares_for_value(1, 10, 0);
+        assert_eq!(
+            result,
+            Err(FractionalError::ReentrantCall),
+            "[regression #493] swap_shares_for_value must return ReentrantCall"
+        );
+        f.reentrancy_guard.exit();
+    }
+
+    // ── Issue #493: Fractional — add_liquidity ──────────────────────────────
+
+    /// Regression for issue #493: add_liquidity must return ReentrantCall
+    /// when the reentrancy guard is already locked.
+    #[ink::test]
+    fn fractional_add_liquidity_reentrant_call_regression() {
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 1000);
+
+        f.reentrancy_guard.enter().expect("guard enter");
+        test::set_value_transferred::<DefaultEnvironment>(500);
+        let result = f.add_liquidity(1, 100, 0);
+        assert_eq!(
+            result,
+            Err(FractionalError::ReentrantCall),
+            "[regression #493] add_liquidity must return ReentrantCall"
+        );
+        f.reentrancy_guard.exit();
+    }
+
+    // ── Issue #493: Fractional — remove_liquidity ───────────────────────────
+
+    /// Regression for issue #493: remove_liquidity must return ReentrantCall
+    /// when the reentrancy guard is already locked.
+    #[ink::test]
+    fn fractional_remove_liquidity_reentrant_call_regression() {
+        let mut f = Fractional::new();
+        test::set_caller::<DefaultEnvironment>(alice());
+        f.mint_shares(alice(), 1, 1000);
+        test::set_value_transferred::<DefaultEnvironment>(1000);
+        let lp = f.add_liquidity(1, 200, 0).unwrap();
+
+        f.reentrancy_guard.enter().expect("guard enter");
+        let result = f.remove_liquidity(1, lp, 0, 0);
+        assert_eq!(
+            result,
+            Err(FractionalError::ReentrantCall),
+            "[regression #493] remove_liquidity must return ReentrantCall"
+        );
+        f.reentrancy_guard.exit();
+    }
+
+    // ── Staking contract — unstake ───────────────────────────────────────────
+
+    /// Regression: Staking::unstake must be reentrancy-guarded and return
+    /// ReentrantCall when the guard is locked.
+    #[ink::test]
+    fn staking_unstake_reentrant_call_regression() {
+        use staking::staking::{Error as StakingError, LockPeriod, Staking};
+
+        let mut s = Staking::new(500, 1_000);
+        test::set_caller::<DefaultEnvironment>(alice());
+        s.stake(5_000, LockPeriod::Flexible).expect("stake");
+
+        s.reentrancy_guard.enter().expect("guard enter");
+        let result = s.unstake();
+        assert_eq!(
+            result,
+            Err(StakingError::ReentrantCall),
+            "[regression] staking::unstake must return ReentrantCall"
+        );
+        s.reentrancy_guard.exit();
+    }
+
+    // ── Staking contract — claim_rewards ────────────────────────────────────
+
+    /// Regression: Staking::claim_rewards must be reentrancy-guarded.
+    #[ink::test]
+    fn staking_claim_rewards_reentrant_call_regression() {
+        use staking::staking::{Error as StakingError, LockPeriod, Staking};
+
+        let mut s = Staking::new(500, 1_000);
+        test::set_caller::<DefaultEnvironment>(alice());
+        s.stake(5_000, LockPeriod::Flexible).expect("stake");
+        s.fund_reward_pool(100_000).expect("fund pool");
+
+        s.reentrancy_guard.enter().expect("guard enter");
+        let result = s.claim_rewards();
+        assert_eq!(
+            result,
+            Err(StakingError::ReentrantCall),
+            "[regression] staking::claim_rewards must return ReentrantCall"
+        );
+        s.reentrancy_guard.exit();
+    }
+}

--- a/tests/regression/reinsurance_stats_derives.rs
+++ b/tests/regression/reinsurance_stats_derives.rs
@@ -1,0 +1,98 @@
+/// # Regression: ReinsuranceStats Encode / Decode / TypeInfo derives
+///
+/// Bug reference: ReinsuranceStats was missing `scale::Encode`, `scale::Decode`,
+/// and `scale_info::TypeInfo` derives, causing compile errors whenever the type
+/// was used in a storage mapping or returned from an ink! message.
+///
+/// This module verifies those derives are present and functional.
+#[cfg(test)]
+mod reinsurance_stats_derives {
+    use insurance::insurance::{Insurance, ReinsuranceTreatyType};
+    use scale::{Decode, Encode};
+
+    // We import the concrete type so the test fails to compile if the derives
+    // are removed again.
+    use insurance::insurance::ReinsuranceStats;
+
+    /// Bug: ReinsuranceStats was missing Encode / Decode derives.
+    /// Regression: encoding and then decoding must produce an identical value.
+    #[test]
+    fn reinsurance_stats_encode_decode_roundtrip() {
+        let original = ReinsuranceStats {
+            agreement_id: 42,
+            treaty_type: ReinsuranceTreatyType::QuotaShare,
+            total_ceded_premiums: 1_000_000,
+            total_recoveries: 500_000,
+            cession_count: 10,
+            recovery_count: 5,
+            net_recovery: -500_000,
+        };
+
+        // Encode
+        let encoded = original.encode();
+        assert!(!encoded.is_empty(), "encoded bytes must be non-empty");
+
+        // Decode
+        let decoded =
+            ReinsuranceStats::decode(&mut encoded.as_slice()).expect("decode must succeed");
+
+        assert_eq!(
+            decoded.agreement_id, original.agreement_id,
+            "agreement_id must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.treaty_type, original.treaty_type,
+            "treaty_type must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.total_ceded_premiums, original.total_ceded_premiums,
+            "total_ceded_premiums must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.total_recoveries, original.total_recoveries,
+            "total_recoveries must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.cession_count, original.cession_count,
+            "cession_count must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.recovery_count, original.recovery_count,
+            "recovery_count must survive encode/decode"
+        );
+        assert_eq!(
+            decoded.net_recovery, original.net_recovery,
+            "net_recovery must survive encode/decode"
+        );
+    }
+
+    /// Bug: TypeInfo derive was missing, preventing use in ink! messages.
+    /// Regression: the TypeInfo implementation must be accessible at compile
+    /// time — this is validated implicitly by the trait bound check below.
+    #[test]
+    fn reinsurance_stats_type_info_implemented() {
+        // If TypeInfo is not derived, scale_info::TypeInfo::<any> won't be
+        // satisfied and this function body won't compile.
+        fn assert_type_info<T: scale_info::TypeInfo + 'static>() {}
+        assert_type_info::<ReinsuranceStats>();
+    }
+
+    /// Verify zero-value default fields encode correctly (boundary condition).
+    #[test]
+    fn reinsurance_stats_zero_values_encode() {
+        let zero = ReinsuranceStats {
+            agreement_id: 0,
+            treaty_type: ReinsuranceTreatyType::ExcessOfLoss,
+            total_ceded_premiums: 0,
+            total_recoveries: 0,
+            cession_count: 0,
+            recovery_count: 0,
+            net_recovery: 0,
+        };
+        let encoded = zero.encode();
+        let decoded =
+            ReinsuranceStats::decode(&mut encoded.as_slice()).expect("zero-value decode");
+        assert_eq!(decoded.agreement_id, 0);
+        assert_eq!(decoded.net_recovery, 0);
+    }
+}


### PR DESCRIPTION
## Issue #493 - Security: Add reentrancy guard to fractional ownership contract
- Add ReentrantCall variant to FractionalError
- Implement From<ReentrancyError> for FractionalError
- Add reentrancy_guard field to Fractional storage
- Apply non_reentrant! macro to buy_shares, redeem_shares, swap_shares_for_value
- Apply non_reentrant! macro to add_liquidity and remove_liquidity
- Add 6 reentrancy tests verifying guard behavior on each protected function

## Issue #487 - Regression test suite for previously fixed bugs
- Fix ReinsuranceStats missing derives (FraudDetectionStats was missing closing brace, ReinsuranceStats was missing Encode/Decode/TypeInfo derives)
- Create tests/regression/ directory with:
  - reinsurance_stats_derives.rs: encode/decode/TypeInfo roundtrip tests
  - reentrancy_guard.rs: guard regression on each protected function
  - closed_bugs.rs: miscellaneous closed-bug regressions (AMM k invariant, min stake enforcement, double-stake prevention, governance threshold)

## Issue #488 - Integration tests for governance <-> staking interaction
- Create tests/integration_governance_staking.rs with 9 tests:
  - Staking creates governance power correctly
  - Delegation transfers governance power to delegate
  - Unstaking removes governance power
  - Proposal creation requires minimum voting power (NoVotingPower check)
  - Voting weight matches staked amount including delegated power
  - Multiple stakers vote with correct weights
  - Governance proposal lifecycle (create -> vote -> Approved)
  - Non-signer cannot create governance proposals
  - Re-delegation updates governance power correctly

## Issue #489 - Chaos engineering tests for bridge failure scenarios
- Create tests/bridge_chaos.rs with 8 chaos tests:
  - Validator key compromise (rapid failed signatures, replay prevention)
  - Oracle price manipulation (large/zero amounts, fee coherence)
  - Network partition / timeout handling (request expiry, rollback)
  - Rapid pause/unpause cycles (20 cycles, state consistency, audit log)
  - Multiple concurrent recovery operations (5 simultaneous rollbacks)
  - Bridge state consistency after chaos
  - No funds double-spent (execute idempotency invariant)
  - Pause blocks writes but not reads

## Supporting changes
- tests/Cargo.toml: add fractional, governance, staking, propchain-bridge, propchain-insurance dependencies with std feature flags
- tests/lib.rs: register integration_governance_staking, bridge_chaos, and regression module declarations
closes #493
closes #488
closes #487
closes #489