### PR TITLE
feat(property-token): implement batch mint for institutional issuers

### DIFF
--- a/contracts/property-token/src/lib.rs
+++ b/contracts/property-token/src/lib.rs
@@ -561,6 +561,15 @@ pub mod property_token {
         pub reason: String,
     }
 
+    // --- Batch Mint Events (Issue #556) ---
+    #[ink(event)]
+    pub struct BatchMinted {
+        #[ink(topic)]
+        pub owner: AccountId,
+        pub token_ids: Vec<TokenId>,
+        pub count: u32,
+    }
+
     impl Default for PropertyToken {
         fn default() -> Self {
             Self::new()
@@ -2510,6 +2519,76 @@ pub mod property_token {
             self.total_supply += issued_tokens.len() as u64;
 
             Ok(issued_tokens)
+        }
+
+        /// Batch-mints multiple NFTs atomically for institutional issuers (Issue #556).
+        /// Assigns all tokens to `owner` with corresponding `metadata_uris`.
+        /// Aborts entirely if any validation fails (all-or-nothing semantics).
+        #[ink(message)]
+        pub fn mint_batch(
+            &mut self,
+            owner: AccountId,
+            metadata_uris: Vec<String>,
+        ) -> Result<Vec<TokenId>, Error> {
+            if metadata_uris.is_empty() {
+                return Err(Error::InvalidAmount);
+            }
+            if metadata_uris.len() > self.max_batch_size as usize {
+                return Err(Error::BatchSizeExceeded);
+            }
+            let caller = self.env().caller();
+            if caller != self.admin && caller != owner {
+                return Err(Error::Unauthorized);
+            }
+
+            let current_time = self.env().block_timestamp();
+            let mut issued_ids: Vec<TokenId> = Vec::new();
+
+            for uri in &metadata_uris {
+                self.token_counter += 1;
+                let token_id = self.token_counter;
+
+                self.token_owner.insert(token_id, &owner);
+                let balance = self.owner_token_count.get(owner).unwrap_or(0);
+                self.owner_token_count.insert(owner, &(balance + 1));
+                self.balances.insert((&owner, &token_id), &1u128);
+
+                if !uri.is_empty() {
+                    self.token_uris.insert(token_id, uri);
+                }
+
+                let initial_transfer = OwnershipTransfer {
+                    from: AccountId::from([0u8; 32]),
+                    to: owner,
+                    timestamp: current_time,
+                    transaction_hash: Hash::default(),
+                };
+                self.ownership_history_count.insert(token_id, &1u32);
+                self.ownership_history_items
+                    .insert((token_id, 0), &initial_transfer);
+
+                let compliance_info = ComplianceInfo {
+                    verified: false,
+                    verification_date: 0,
+                    verifier: AccountId::from([0u8; 32]),
+                    compliance_type: String::from("KYC"),
+                };
+                self.compliance_flags.insert(token_id, &compliance_info);
+                self.legal_documents_count.insert(token_id, &0u32);
+
+                issued_ids.push(token_id);
+            }
+
+            self.total_supply += issued_ids.len() as u64;
+
+            let count = issued_ids.len() as u32;
+            self.env().emit_event(BatchMinted {
+                owner,
+                token_ids: issued_ids.clone(),
+                count,
+            });
+
+            Ok(issued_ids)
         }
 
         /// Property-specific: Attaches a legal document to a token

--- a/contracts/property-token/src/tests.rs
+++ b/contracts/property-token/src/tests.rs
@@ -144,6 +144,96 @@ mod tests {
         assert_eq!(contract.metadata_version_count(token_id), 0);
     }
 
+    // =========================================================================
+    // Issue #556 – mint_batch tests
+    // =========================================================================
+
+    #[ink::test]
+    fn test_mint_batch_basic() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let uris = vec![
+            String::from("ipfs://QmProp1"),
+            String::from("ipfs://QmProp2"),
+            String::from("ipfs://QmProp3"),
+        ];
+        let result = contract.mint_batch(accounts.alice, uris);
+        assert!(result.is_ok());
+        let ids = result.unwrap();
+        assert_eq!(ids.len(), 3);
+        assert_eq!(contract.total_supply(), 3);
+    }
+
+    #[ink::test]
+    fn test_mint_batch_assigns_correct_owner() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let uris = vec![String::from("ipfs://QmA"), String::from("ipfs://QmB")];
+        let ids = contract.mint_batch(accounts.alice, uris).unwrap();
+
+        for id in &ids {
+            assert_eq!(contract.owner_of(*id), Some(accounts.alice));
+        }
+        assert_eq!(contract.balance_of(accounts.alice), 2);
+    }
+
+    #[ink::test]
+    fn test_mint_batch_stores_uris() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let uris = vec![String::from("ipfs://QmX"), String::from("ipfs://QmY")];
+        let ids = contract.mint_batch(accounts.alice, uris.clone()).unwrap();
+
+        for (idx, id) in ids.iter().enumerate() {
+            let stored = contract.token_uris.get(id);
+            assert_eq!(stored, Some(uris[idx].clone()));
+        }
+    }
+
+    #[ink::test]
+    fn test_mint_batch_empty_fails() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let result = contract.mint_batch(accounts.alice, vec![]);
+        assert_eq!(result, Err(Error::InvalidAmount));
+    }
+
+    #[ink::test]
+    fn test_mint_batch_unauthorized_fails() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+
+        // Bob tries to mint tokens owned by Alice – caller must be owner or admin
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result = contract.mint_batch(
+            accounts.alice,
+            vec![String::from("ipfs://QmUnauth")],
+        );
+        assert_eq!(result, Err(Error::Unauthorized));
+    }
+
+    #[ink::test]
+    fn test_mint_batch_token_ids_sequential() {
+        let mut contract = setup_contract();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let uris = vec![
+            String::from("ipfs://QmSeq1"),
+            String::from("ipfs://QmSeq2"),
+        ];
+        let ids = contract.mint_batch(accounts.alice, uris).unwrap();
+        assert_eq!(ids[0] + 1, ids[1], "Token IDs must be sequential");
+    }
+
     fn setup_contract() -> PropertyToken {
         PropertyToken::new()
     }


### PR DESCRIPTION
## Summary

- Add `mint_batch(owner, metadata_uris)` that mints multiple NFTs in a single atomic transaction
- All-or-nothing semantics: the entire batch reverts if any step fails
- Emits a single `BatchMinted` event carrying all assigned token IDs and count
- Enforces `max_batch_size` and caller-authorization checks
- 6 new unit tests covering happy path, owner/URI assignment, empty input, unauthorized caller, and sequential ID assignment

## Test plan

- [ ] `test_mint_batch_basic` - mints 3 tokens, checks supply
- [ ] `test_mint_batch_assigns_correct_owner` - owner and balance correct
- [ ] `test_mint_batch_stores_uris` - URI mapping populated
- [ ] `test_mint_batch_empty_fails` - returns `InvalidAmount`
- [ ] `test_mint_batch_unauthorized_fails` - returns `Unauthorized`
- [ ] `test_mint_batch_token_ids_sequential` - IDs are contiguous

closes #556