### PR TITLE
feat(property-token): metadata versioning with immutable historical snapshots

### DIFF
--- a/contracts/property-token/src/lib.rs
+++ b/contracts/property-token/src/lib.rs
@@ -128,6 +128,12 @@ pub mod property_token {
         snapshot_counter: Mapping<TokenId, u64>,
         snapshots: Mapping<(TokenId, u64), Snapshot>,
         account_snapshots: Mapping<(AccountId, TokenId, u64), u128>, // (account, token_id, snapshot_id) -> balance
+
+        // Metadata versioning (Issue #557)
+        /// Number of historical versions stored for a token (0 = no updates yet)
+        metadata_version_count: Mapping<TokenId, u32>,
+        /// Versioned metadata snapshots: (token_id, version_number) -> MetadataVersion
+        metadata_versions: Mapping<(TokenId, u32), MetadataVersion>,
     }
 
     // Data types extracted to types.rs (Issue #101)
@@ -665,6 +671,10 @@ pub mod property_token {
                 share_last_reward_block: Mapping::default(),
                 share_reward_rate_bps: Mapping::default(),
                 share_reward_pool: Mapping::default(),
+
+                // Metadata versioning (Issue #557)
+                metadata_version_count: Mapping::default(),
+                metadata_versions: Mapping::default(),
             }
         }
 
@@ -1918,7 +1928,9 @@ pub mod property_token {
         // Metadata Methods
         // =========================================================================
 
-        /// Updates the on-chain metadata for a property
+        /// Updates the on-chain metadata for a property (Issue #557).
+        /// The previous metadata is snapshotted as an immutable `MetadataVersion`
+        /// before the new metadata is applied, preserving full history.
         #[ink(message)]
         pub fn update_property_metadata(
             &mut self,
@@ -1935,6 +1947,22 @@ pub mod property_token {
                 .token_properties
                 .get(token_id)
                 .ok_or(Error::TokenNotFound)?;
+
+            // Snapshot the CURRENT metadata before overwriting it
+            let version_number = self
+                .metadata_version_count
+                .get(token_id)
+                .unwrap_or(0)
+                .saturating_add(1);
+            let snapshot = MetadataVersion {
+                version_number,
+                metadata: property_info.metadata.clone(),
+                updated_by: caller,
+                updated_at: self.env().block_timestamp(),
+            };
+            self.metadata_versions.insert((token_id, version_number), &snapshot);
+            self.metadata_version_count.insert(token_id, &version_number);
+
             property_info.metadata = metadata;
             self.token_properties.insert(token_id, &property_info);
 
@@ -1944,6 +1972,31 @@ pub mod property_token {
             });
 
             Ok(())
+        }
+
+        /// Returns the immutable metadata snapshot at `version` for `token_id` (Issue #557).
+        /// Version numbers are 1-based; the initial mint metadata is at the live
+        /// `token_properties` mapping and is snapshotted as version 1 on the first update.
+        #[ink(message)]
+        pub fn get_metadata_at(
+            &self,
+            token_id: TokenId,
+            version: u32,
+        ) -> Option<MetadataVersion> {
+            if version == 0 {
+                return None;
+            }
+            let count = self.metadata_version_count.get(token_id).unwrap_or(0);
+            if version > count {
+                return None;
+            }
+            self.metadata_versions.get((token_id, version))
+        }
+
+        /// Returns the total number of historical versions stored for `token_id` (Issue #557).
+        #[ink(message)]
+        pub fn metadata_version_count(&self, token_id: TokenId) -> u32 {
+            self.metadata_version_count.get(token_id).unwrap_or(0)
         }
 
         /// Sets a custom URI for a token, overriding the default generated format

--- a/contracts/property-token/src/tests.rs
+++ b/contracts/property-token/src/tests.rs
@@ -5,6 +5,145 @@ mod tests {
     use super::*;
     use ink::env::{test, DefaultEnvironment};
 
+    // =========================================================================
+    // Issue #557 – metadata versioning tests
+    // =========================================================================
+
+    fn make_metadata(location: &str, valuation: u128) -> PropertyMetadata {
+        PropertyMetadata {
+            location: String::from(location),
+            size: 1000,
+            legal_description: String::from("Test property"),
+            valuation,
+            documents_url: String::from("ipfs://docs"),
+        }
+    }
+
+    #[ink::test]
+    fn test_metadata_version_count_starts_at_zero() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("123 Main St", 500_000))
+            .unwrap();
+
+        assert_eq!(contract.metadata_version_count(token_id), 0);
+    }
+
+    #[ink::test]
+    fn test_first_update_creates_version_one() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("123 Main St", 500_000))
+            .unwrap();
+
+        contract
+            .update_property_metadata(token_id, make_metadata("123 Main St Updated", 600_000))
+            .unwrap();
+
+        assert_eq!(contract.metadata_version_count(token_id), 1);
+    }
+
+    #[ink::test]
+    fn test_get_metadata_at_returns_snapshot() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let original = make_metadata("Original Location", 100_000);
+        let token_id = contract
+            .register_property_with_token(original.clone())
+            .unwrap();
+
+        let updated = make_metadata("Updated Location", 200_000);
+        contract
+            .update_property_metadata(token_id, updated.clone())
+            .unwrap();
+
+        let v1 = contract.get_metadata_at(token_id, 1).expect("version 1 must exist");
+        assert_eq!(v1.version_number, 1);
+        assert_eq!(v1.metadata.location, original.location);
+        assert_eq!(v1.metadata.valuation, original.valuation);
+    }
+
+    #[ink::test]
+    fn test_multiple_versions_tracked() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("v0", 100_000))
+            .unwrap();
+
+        contract
+            .update_property_metadata(token_id, make_metadata("v1", 200_000))
+            .unwrap();
+        contract
+            .update_property_metadata(token_id, make_metadata("v2", 300_000))
+            .unwrap();
+        contract
+            .update_property_metadata(token_id, make_metadata("v3", 400_000))
+            .unwrap();
+
+        assert_eq!(contract.metadata_version_count(token_id), 3);
+
+        let v1 = contract.get_metadata_at(token_id, 1).unwrap();
+        let v2 = contract.get_metadata_at(token_id, 2).unwrap();
+        let v3 = contract.get_metadata_at(token_id, 3).unwrap();
+        assert_eq!(v1.metadata.valuation, 100_000);
+        assert_eq!(v2.metadata.valuation, 200_000);
+        assert_eq!(v3.metadata.valuation, 300_000);
+    }
+
+    #[ink::test]
+    fn test_get_metadata_at_version_zero_returns_none() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("Test", 100_000))
+            .unwrap();
+
+        assert_eq!(contract.get_metadata_at(token_id, 0), None);
+    }
+
+    #[ink::test]
+    fn test_get_metadata_at_nonexistent_version_returns_none() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("Test", 100_000))
+            .unwrap();
+
+        assert_eq!(contract.get_metadata_at(token_id, 5), None);
+    }
+
+    #[ink::test]
+    fn test_metadata_update_unauthorized() {
+        let mut contract = PropertyToken::new();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        let token_id = contract
+            .register_property_with_token(make_metadata("Test", 100_000))
+            .unwrap();
+
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        let result =
+            contract.update_property_metadata(token_id, make_metadata("Hacked", 999_999));
+        assert_eq!(result, Err(Error::Unauthorized));
+        assert_eq!(contract.metadata_version_count(token_id), 0);
+    }
+
     fn setup_contract() -> PropertyToken {
         PropertyToken::new()
     }

--- a/contracts/property-token/src/types.rs
+++ b/contracts/property-token/src/types.rs
@@ -360,3 +360,27 @@ pub struct ShareStakeInfo {
     pub lock_period: LockPeriod,
     pub reward_debt: u128,
 }
+
+/// Immutable snapshot of property metadata at a specific version (Issue #557).
+/// Each call to `update_property_metadata` appends a new entry; version numbers
+/// start at 1 and are strictly increasing. Version 0 is reserved for the
+/// initial metadata set at mint time.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    scale::Encode,
+    scale::Decode,
+    ink::storage::traits::StorageLayout,
+)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub struct MetadataVersion {
+    /// 1-based version number; version 0 is the original mint metadata.
+    pub version_number: u32,
+    /// The metadata snapshot at this version.
+    pub metadata: PropertyMetadata,
+    /// Account that triggered the metadata update.
+    pub updated_by: AccountId,
+    /// Block timestamp when this version was recorded.
+    pub updated_at: u64,
+}


### PR DESCRIPTION
## Summary

- Add `MetadataVersion` struct to `types.rs` capturing a point-in-time metadata snapshot (version number, metadata, updater, timestamp)
- Add `metadata_version_count: Mapping<TokenId, u32>` and `metadata_versions: Mapping<(TokenId, u32), MetadataVersion>` storage fields
- Extend `update_property_metadata` to snapshot the *current* metadata as an immutable version entry before applying the update
- Expose `get_metadata_at(token_id, version)` and `metadata_version_count(token_id)` read messages
- History tracking pattern follows `contracts/oracle/src/lib.rs`; version numbers are 1-based and strictly increasing

## Test plan

- [ ] Version count starts at 0 after mint
- [ ] First update creates version 1
- [ ] `get_metadata_at` returns the correct pre-update snapshot
- [ ] Three successive updates produce three versioned entries with correct values
- [ ] Version 0 returns `None`; out-of-range version returns `None`
- [ ] Unauthorized update leaves version count unchanged

closes #557