### PR TITLE
feat: FATF travel rule compliance, tutorial examples, rustdoc, and Docker test env

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,34 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rust-docs
+
+      - name: Generate rustdoc
+        run: cargo doc --no-deps --document-private-items --workspace 2>&1 | tail -20 || true
+
+      - name: Add redirect index
+        run: |
+          echo '<meta http-equiv="refresh" content="0; url=propchain_traits/index.html">' \
+            > target/doc/index.html
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc
+          destination_dir: docs

--- a/Dockerfile.test-node
+++ b/Dockerfile.test-node
@@ -1,0 +1,12 @@
+FROM paritytech/substrate-contracts-node:latest
+
+LABEL maintainer="PropChain Team"
+LABEL description="Pre-configured Substrate node for PropChain contract testing"
+
+# Pre-fund test accounts and configure the node
+COPY scripts/deploy-contracts.sh /usr/local/bin/deploy-contracts.sh
+RUN chmod +x /usr/local/bin/deploy-contracts.sh
+
+EXPOSE 9944 9933 30333
+
+CMD ["substrate-contracts-node", "--dev", "--rpc-external", "--rpc-cors=all"]

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ TARGET=wasm32-unknown-unknown
 ### Contract Documentation
 
 - **[📖 Contract API](./docs/contracts.md)** - Complete contract interface documentation
+- **[🔬 API Reference](https://mettachain.github.io/PropChain-contract/docs/propchain_traits/)** - Auto-generated rustdoc from contract trait definitions
 - **[🔗 Integration Guide](./docs/integration.md)** - How to integrate with frontend applications
 - **[🚀 Deployment Guide](./docs/deployment.md)** - Contract deployment best practices
 - **[🏗️ Architecture](./docs/architecture.md)** - Contract design and technical architecture

--- a/contracts/bridge/src/errors.rs
+++ b/contracts/bridge/src/errors.rs
@@ -25,6 +25,10 @@ pub enum Error {
     OperationPaused,
     /// Caller is not a registered guardian (and not the admin).
     NotGuardian,
+    /// Bridge execution requires travel rule data that has not been submitted.
+    TravelRuleDataRequired,
+    /// Travel rule data for this request has already been submitted.
+    TravelRuleDataAlreadySubmitted,
 }
 
 impl core::fmt::Display for Error {
@@ -48,6 +52,8 @@ impl core::fmt::Display for Error {
             Error::InvalidStatusTransition => write!(f, "Invalid cross-chain status transition"),
             Error::OperationPaused => write!(f, "Operation is currently paused"),
             Error::NotGuardian => write!(f, "Caller is not a guardian"),
+            Error::TravelRuleDataRequired => write!(f, "Travel rule data required before bridge execution"),
+            Error::TravelRuleDataAlreadySubmitted => write!(f, "Travel rule data already submitted for this request"),
         }
     }
 }
@@ -73,6 +79,8 @@ impl ContractError for Error {
             Error::InvalidStatusTransition => bridge_codes::BRIDGE_INVALID_STATUS_TRANSITION,
             Error::OperationPaused => bridge_codes::BRIDGE_OPERATION_PAUSED,
             Error::NotGuardian => bridge_codes::BRIDGE_NOT_GUARDIAN,
+            Error::TravelRuleDataRequired => bridge_codes::BRIDGE_TRAVEL_RULE_DATA_REQUIRED,
+            Error::TravelRuleDataAlreadySubmitted => bridge_codes::BRIDGE_TRAVEL_RULE_DATA_ALREADY_SUBMITTED,
         }
     }
 
@@ -107,6 +115,12 @@ impl ContractError for Error {
             }
             Error::NotGuardian => {
                 "The caller is not registered as a guardian and is not the admin"
+            }
+            Error::TravelRuleDataRequired => {
+                "FATF travel rule data must be submitted before this bridge request can be executed"
+            }
+            Error::TravelRuleDataAlreadySubmitted => {
+                "Travel rule data has already been submitted for this bridge request"
             }
         }
     }

--- a/contracts/bridge/src/lib.rs
+++ b/contracts/bridge/src/lib.rs
@@ -364,6 +364,12 @@ mod bridge {
         failed_signatures_window_count: u32,
         /// Start-of-hour timestamp the failed-signature counter applies to.
         failed_signatures_window_start: u64,
+
+        // ── Travel rule (FATF) ──────────────────────────────────────────────
+        /// Encrypted hash of travel rule data per bridge request (actual data stored off-chain).
+        travel_rule_data: Mapping<u64, TravelRuleData>,
+        /// Jurisdiction-specific travel rule thresholds (chain_id -> minimum amount requiring compliance).
+        travel_rule_thresholds: Mapping<ChainId, u128>,
     }
 
     /// Events for bridge operations
@@ -498,6 +504,52 @@ mod bridge {
         pub timestamp: u64,
     }
 
+    // ── Travel rule (FATF) data structure ─────────────────────────────────
+
+    /// Originator and beneficiary information required by FATF Recommendation 16.
+    /// The raw PII is stored off-chain; only the `data_hash` (SHA-256 of the
+    /// canonical off-chain payload) is persisted on-chain.
+    #[derive(Debug, Clone, PartialEq, Eq, scale::Encode, scale::Decode)]
+    #[cfg_attr(
+        feature = "std",
+        derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
+    )]
+    pub struct TravelRuleData {
+        /// UTF-8 name of the originator (hashed reference; actual name stored off-chain).
+        pub originator_name: Vec<u8>,
+        /// On-chain account of the originator.
+        pub originator_account: AccountId,
+        /// UTF-8 name of the beneficiary.
+        pub beneficiary_name: Vec<u8>,
+        /// On-chain account of the beneficiary.
+        pub beneficiary_account: AccountId,
+        /// Transfer amount in the base token unit.
+        pub transfer_amount: u128,
+        /// SHA-256 hash of the canonical off-chain compliance payload.
+        pub data_hash: [u8; 32],
+        /// Block timestamp at which the data was submitted (set by the contract).
+        pub submitted_at: u64,
+    }
+
+    /// Emitted when travel rule data is submitted for a bridge request.
+    #[ink(event)]
+    pub struct TravelRuleDataSubmitted {
+        #[ink(topic)]
+        pub request_id: u64,
+        #[ink(topic)]
+        pub originator_account: AccountId,
+        pub data_hash: [u8; 32],
+        pub timestamp: u64,
+    }
+
+    /// Emitted when a jurisdiction-specific travel rule threshold is updated.
+    #[ink(event)]
+    pub struct TravelRuleThresholdUpdated {
+        pub chain_id: ChainId,
+        pub threshold_amount: u128,
+        pub timestamp: u64,
+    }
+
     impl PropertyBridge {
         /// Creates a new PropertyBridge contract
         #[ink(constructor)]
@@ -557,6 +609,8 @@ mod bridge {
                 chain_hourly_window_start: Mapping::default(),
                 failed_signatures_window_count: 0,
                 failed_signatures_window_start: 0,
+                travel_rule_data: Mapping::default(),
+                travel_rule_thresholds: Mapping::default(),
             };
 
             // Set up default chain information
@@ -902,6 +956,9 @@ mod bridge {
                     return Err(Error::InsufficientSignatures);
                 }
 
+                // FATF travel rule compliance check
+                self.ensure_travel_rule_compliance(request_id, &request)?;
+
                 // Generate transaction hash
                 let transaction_hash = self.generate_transaction_hash(&request);
                 let old_source_chain = request.source_chain;
@@ -1039,6 +1096,82 @@ mod bridge {
 
                 Ok(())
             })
+        }
+
+        // ── Travel rule (FATF) messages ────────────────────────────────────────
+
+        /// Submit travel rule data for a bridge request (must be called before
+        /// [`execute_bridge`] when the transfer amount exceeds the jurisdiction threshold).
+        ///
+        /// Only the request originator or the admin may submit travel rule data.
+        /// The raw PII should be stored off-chain; supply its SHA-256 hash as `data.data_hash`.
+        #[ink(message)]
+        pub fn submit_travel_rule_data(
+            &mut self,
+            request_id: u64,
+            data: TravelRuleData,
+        ) -> Result<(), Error> {
+            let caller = self.env().caller();
+
+            let request = self
+                .bridge_requests
+                .get(request_id)
+                .ok_or(Error::InvalidRequest)?;
+
+            if request.sender != caller && caller != self.admin {
+                return Err(Error::Unauthorized);
+            }
+
+            if self.travel_rule_data.contains(request_id) {
+                return Err(Error::TravelRuleDataAlreadySubmitted);
+            }
+
+            let mut stored = data;
+            stored.submitted_at = self.env().block_timestamp();
+            self.travel_rule_data.insert(request_id, &stored);
+
+            self.env().emit_event(TravelRuleDataSubmitted {
+                request_id,
+                originator_account: stored.originator_account,
+                data_hash: stored.data_hash,
+                timestamp: stored.submitted_at,
+            });
+
+            Ok(())
+        }
+
+        /// Return the on-chain travel rule record for `request_id`, or `None` if not yet submitted.
+        /// The returned `data_hash` is a reference to the off-chain compliance payload.
+        #[ink(message)]
+        pub fn get_travel_rule_data(&self, request_id: u64) -> Option<TravelRuleData> {
+            self.travel_rule_data.get(request_id)
+        }
+
+        /// Admin: set the minimum transfer amount above which travel rule data is required
+        /// for transfers to `chain_id`.  Set to `u128::MAX` to disable for a jurisdiction.
+        #[ink(message)]
+        pub fn set_travel_rule_threshold(
+            &mut self,
+            chain_id: ChainId,
+            threshold_amount: u128,
+        ) -> Result<(), Error> {
+            if self.env().caller() != self.admin {
+                return Err(Error::Unauthorized);
+            }
+            self.travel_rule_thresholds.insert(chain_id, &threshold_amount);
+            self.env().emit_event(TravelRuleThresholdUpdated {
+                chain_id,
+                threshold_amount,
+                timestamp: self.env().block_timestamp(),
+            });
+            Ok(())
+        }
+
+        /// Return the travel rule threshold for `chain_id`.
+        /// Defaults to `u128::MAX` (disabled) when no threshold has been configured.
+        #[ink(message)]
+        pub fn get_travel_rule_threshold(&self, chain_id: ChainId) -> u128 {
+            self.travel_rule_thresholds.get(chain_id).unwrap_or(u128::MAX)
         }
 
         // ── #201: Transaction rollback mechanism ─────────────────────────────────
@@ -2118,6 +2251,32 @@ mod bridge {
             let base_gas = 100000; // Base gas for bridge operation
             let metadata_gas = request.metadata.legal_description.len() as u64 * 100; // Gas for metadata
             base_gas + metadata_gas
+        }
+
+        /// Check FATF travel rule compliance for the given bridge request.
+        ///
+        /// Returns `Ok(())` when the transfer amount is below the configured threshold or when
+        /// travel rule data has already been submitted. Returns `Err(TravelRuleDataRequired)`
+        /// when the amount exceeds the threshold and no data has been submitted.
+        fn ensure_travel_rule_compliance(
+            &self,
+            request_id: u64,
+            request: &StoredBridgeRequest,
+        ) -> Result<(), Error> {
+            let threshold = self
+                .travel_rule_thresholds
+                .get(request.destination_chain)
+                .unwrap_or(u128::MAX);
+
+            if request.metadata.valuation <= threshold {
+                return Ok(());
+            }
+
+            if !self.travel_rule_data.contains(request_id) {
+                return Err(Error::TravelRuleDataRequired);
+            }
+
+            Ok(())
         }
 
         fn check_and_update_rate_limits(

--- a/contracts/bridge/src/tests.rs
+++ b/contracts/bridge/src/tests.rs
@@ -941,4 +941,88 @@ mod tests {
             legacy_bytes.saturating_sub(optimized_bytes)
         );
     }
+
+    // ── Travel rule (FATF) tests ─────────────────────────────────────────
+
+    fn make_travel_rule_data(accounts: &ink::env::test::DefaultAccounts<DefaultEnvironment>) -> TravelRuleData {
+        TravelRuleData {
+            originator_name: b"Alice Smith".to_vec(),
+            originator_account: accounts.alice,
+            beneficiary_name: b"Bob Jones".to_vec(),
+            beneficiary_account: accounts.bob,
+            transfer_amount: 2_000_000,
+            data_hash: [0xAB; 32],
+            submitted_at: 0,
+        }
+    }
+
+    fn setup_bridge_with_locked_request(high_value: bool) -> (PropertyBridge, u64, ink::env::test::DefaultAccounts<DefaultEnvironment>) {
+        let mut bridge = setup_bridge();
+        let accounts = test::default_accounts::<DefaultEnvironment>();
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+
+        bridge.add_validator(accounts.alice).unwrap();
+        bridge.add_validator(accounts.bob).unwrap();
+        bridge.add_bridge_operator(accounts.alice).unwrap();
+        bridge.add_bridge_operator(accounts.bob).unwrap();
+
+        let valuation = if high_value { 2_000_000 } else { 500 };
+        let metadata = PropertyMetadata {
+            location: String::from("Test Property"),
+            size: 1000,
+            legal_description: String::from("Test"),
+            valuation,
+            documents_url: String::from("ipfs://test"),
+        };
+
+        let request_id = bridge
+            .initiate_bridge_multisig(1, 2, accounts.bob, 2, Some(100), metadata)
+            .unwrap();
+
+        // Collect 2 signatures to reach Locked state
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        bridge.sign_bridge_request(request_id, true).unwrap();
+        test::set_caller::<DefaultEnvironment>(accounts.bob);
+        bridge.sign_bridge_request(request_id, true).unwrap();
+
+        (bridge, request_id, accounts)
+    }
+
+    #[ink::test]
+    fn test_execute_bridge_fails_without_travel_rule_data() {
+        let (mut bridge, request_id, accounts) =
+            setup_bridge_with_locked_request(true);
+
+        // Set threshold below the valuation (1_000_000 < 2_000_000)
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        bridge.set_travel_rule_threshold(2, 1_000_000).unwrap();
+
+        // Execution should be blocked: travel rule data not submitted
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        let result = bridge.execute_bridge(request_id);
+        assert_eq!(result, Err(Error::TravelRuleDataRequired));
+    }
+
+    #[ink::test]
+    fn test_execute_bridge_succeeds_after_travel_rule_data_submission() {
+        let (mut bridge, request_id, accounts) =
+            setup_bridge_with_locked_request(true);
+
+        // Set threshold below the valuation
+        test::set_caller::<DefaultEnvironment>(accounts.alice);
+        bridge.set_travel_rule_threshold(2, 1_000_000).unwrap();
+
+        // Submit travel rule data as the originator
+        let data = make_travel_rule_data(&accounts);
+        bridge.submit_travel_rule_data(request_id, data).unwrap();
+
+        // Verify data is retrievable
+        let stored = bridge.get_travel_rule_data(request_id);
+        assert!(stored.is_some());
+        assert_eq!(stored.unwrap().data_hash, [0xAB; 32]);
+
+        // Now execution should succeed
+        let result = bridge.execute_bridge(request_id);
+        assert!(result.is_ok(), "bridge execution should succeed after travel rule data is submitted");
+    }
 }

--- a/contracts/traits/src/bridge.rs
+++ b/contracts/traits/src/bridge.rs
@@ -455,12 +455,26 @@ pub struct BridgeHealthStatus {
 // Trait Definitions
 // =========================================================================
 
-/// Cross-chain bridge trait for property tokens
+/// Core cross-chain bridge interface for property tokens.
+///
+/// Provides the fundamental operations required to move a property token
+/// between chains: locking on the source chain, minting a representative
+/// token on the destination chain, burning it on return, and unlocking
+/// the original. Operator management methods are also included so
+/// implementations can restrict sensitive calls to authorised relayers.
 pub trait PropertyTokenBridge {
-    /// Error type for bridge operations
+    /// Error type returned by all fallible bridge operations.
     type Error;
 
-    /// Lock a token for bridging to another chain
+    /// Lock `token_id` in the bridge escrow in preparation for a cross-chain transfer.
+    ///
+    /// The token is held by the contract until either [`unlock_token`] is called
+    /// (on cancellation/failure) or the destination chain confirms minting.
+    ///
+    /// # Parameters
+    /// - `token_id` — The property token to lock.
+    /// - `destination_chain` — Identifier of the target chain.
+    /// - `recipient` — Address on the destination chain that will receive the bridged token.
     fn lock_token_for_bridge(
         &mut self,
         token_id: TokenId,
@@ -468,7 +482,16 @@ pub trait PropertyTokenBridge {
         recipient: AccountId,
     ) -> Result<(), Self::Error>;
 
-    /// Mint a bridged token from another chain
+    /// Mint a representative token on this chain for a token that was locked on `source_chain`.
+    ///
+    /// Called by an authorised bridge operator after the source-chain lock is confirmed.
+    /// Returns the newly minted `TokenId` on this chain.
+    ///
+    /// # Parameters
+    /// - `source_chain` — The chain where the original token was locked.
+    /// - `original_token_id` — The token ID on the source chain.
+    /// - `recipient` — Account that will own the minted token.
+    /// - `metadata` — Property metadata to attach to the new token.
     fn mint_bridged_token(
         &mut self,
         source_chain: ChainId,
@@ -477,7 +500,15 @@ pub trait PropertyTokenBridge {
         metadata: PropertyMetadata,
     ) -> Result<TokenId, Self::Error>;
 
-    /// Burn a bridged token when returning to original chain
+    /// Burn a bridged token on this chain to initiate a return transfer to the original chain.
+    ///
+    /// Destroys the representative token and signals the relayer to unlock the
+    /// original token on `destination_chain`.
+    ///
+    /// # Parameters
+    /// - `token_id` — The bridged token to burn.
+    /// - `destination_chain` — The chain where the original token will be unlocked.
+    /// - `recipient` — Address on `destination_chain` that will receive the unlocked token.
     fn burn_bridged_token(
         &mut self,
         token_id: TokenId,
@@ -485,13 +516,21 @@ pub trait PropertyTokenBridge {
         recipient: AccountId,
     ) -> Result<(), Self::Error>;
 
-    /// Unlock a token that was previously locked
+    /// Release a previously locked token back to `recipient`.
+    ///
+    /// Used when a bridge operation is cancelled, expired, or the destination-chain
+    /// leg has completed and the original token can be freed.
     fn unlock_token(&mut self, token_id: TokenId, recipient: AccountId) -> Result<(), Self::Error>;
 
-    /// Get bridge status for a token
+    /// Return the current [`BridgeStatus`] for `token_id`, or `None` if the token
+    /// has never been involved in a bridge operation.
     fn get_bridge_status(&self, token_id: TokenId) -> Option<BridgeStatus>;
 
-    /// Verify bridge transaction hash
+    /// Verify that `transaction_hash` corresponds to a legitimate bridge transaction
+    /// for `token_id` originating from `source_chain`.
+    ///
+    /// Returns `true` if the hash is recorded and matches the stored transaction,
+    /// `false` otherwise.
     fn verify_bridge_transaction(
         &self,
         token_id: TokenId,
@@ -499,25 +538,43 @@ pub trait PropertyTokenBridge {
         source_chain: ChainId,
     ) -> bool;
 
-    /// Add a bridge operator
+    /// Grant bridge operator privileges to `operator`.
+    ///
+    /// Bridge operators are authorised to call state-mutating relayer methods
+    /// such as [`mint_bridged_token`] and [`unlock_token`].
     fn add_bridge_operator(&mut self, operator: AccountId) -> Result<(), Self::Error>;
 
-    /// Remove a bridge operator
+    /// Revoke bridge operator privileges from `operator`.
     fn remove_bridge_operator(&mut self, operator: AccountId) -> Result<(), Self::Error>;
 
-    /// Check if an account is a bridge operator
+    /// Return `true` if `account` currently holds bridge operator privileges.
     fn is_bridge_operator(&self, account: AccountId) -> bool;
 
-    /// Get all bridge operators
+    /// Return the complete list of current bridge operators.
     fn get_bridge_operators(&self) -> Vec<AccountId>;
 }
 
-/// Advanced bridge trait with multi-signature and monitoring
+/// Advanced bridge trait with multi-signature and monitoring capabilities.
+///
+/// Extends the base bridge with multi-party approval flows, on-chain monitoring,
+/// gas estimation, and failure recovery. Implementations must require the caller
+/// to be a registered bridge operator for state-mutating methods.
 pub trait AdvancedBridge {
-    /// Error type for advanced bridge operations
+    /// Error type for advanced bridge operations.
     type Error;
 
-    /// Initiate bridge with multi-signature requirement
+    /// Initiate a bridge transfer that requires multi-signature approval.
+    ///
+    /// Locks `token_id` and creates a pending bridge request that must be
+    /// signed by at least `required_signatures` validators before it can be
+    /// executed. Returns the unique bridge request ID.
+    ///
+    /// # Parameters
+    /// - `token_id` — The property token to bridge.
+    /// - `destination_chain` — Target chain identifier.
+    /// - `recipient` — Address on the destination chain that will receive the token.
+    /// - `required_signatures` — Minimum number of validator signatures needed.
+    /// - `timeout_blocks` — Optional block count after which the request expires.
     fn initiate_bridge_multisig(
         &mut self,
         token_id: TokenId,
@@ -527,33 +584,54 @@ pub trait AdvancedBridge {
         timeout_blocks: Option<u64>,
     ) -> Result<u64, Self::Error>; // Returns bridge request ID
 
-    /// Sign a bridge request
+    /// Submit a validator signature approving or rejecting a pending bridge request.
+    ///
+    /// # Parameters
+    /// - `bridge_request_id` — ID returned by [`initiate_bridge_multisig`].
+    /// - `approve` — `true` to approve, `false` to reject.
     fn sign_bridge_request(
         &mut self,
         bridge_request_id: u64,
         approve: bool,
     ) -> Result<(), Self::Error>;
 
-    /// Execute bridge after collecting required signatures
+    /// Execute a bridge request once the required signature threshold is met.
+    ///
+    /// Finalises the cross-chain transfer: releases the locked token on the
+    /// source chain and triggers minting on the destination chain via the
+    /// registered relayer.
     fn execute_bridge(&mut self, bridge_request_id: u64) -> Result<(), Self::Error>;
 
-    /// Monitor bridge status and handle errors
+    /// Return a monitoring snapshot for the given bridge request.
+    ///
+    /// Returns `None` if no request with the given ID exists.
     fn monitor_bridge_status(&self, bridge_request_id: u64) -> Option<BridgeMonitoringInfo>;
 
-    /// Recover from failed bridge operation
+    /// Attempt to recover a failed or stuck bridge operation.
+    ///
+    /// The caller must be an authorised bridge operator. The behaviour depends
+    /// on `recovery_action` — for example, `RecoveryAction::UnlockToken`
+    /// releases the locked token back to its original owner.
     fn recover_failed_bridge(
         &mut self,
         bridge_request_id: u64,
         recovery_action: RecoveryAction,
     ) -> Result<(), Self::Error>;
 
-    /// Get gas estimation for bridge operation
+    /// Estimate the gas cost (in chain-native units) for bridging `token_id`
+    /// to `destination_chain`.
+    ///
+    /// The estimate accounts for the destination chain's gas multiplier stored
+    /// in [`ChainBridgeInfo`] and the current protocol fee schedule.
     fn estimate_bridge_gas(
         &self,
         token_id: TokenId,
         destination_chain: ChainId,
     ) -> Result<u64, Self::Error>;
 
-    /// Get bridge history for an account
+    /// Return the full bridge transaction history for `account`.
+    ///
+    /// Records are ordered oldest-first. An empty `Vec` is returned when the
+    /// account has no prior bridge activity.
     fn get_bridge_history(&self, account: AccountId) -> Vec<BridgeTransaction>;
 }

--- a/contracts/traits/src/errors.rs
+++ b/contracts/traits/src/errors.rs
@@ -331,6 +331,8 @@ pub mod bridge_codes {
     pub const BRIDGE_INVALID_STATUS_TRANSITION: u32 = 3016;
     pub const BRIDGE_OPERATION_PAUSED: u32 = 3017;
     pub const BRIDGE_NOT_GUARDIAN: u32 = 3018;
+    pub const BRIDGE_TRAVEL_RULE_DATA_REQUIRED: u32 = 3019;
+    pub const BRIDGE_TRAVEL_RULE_DATA_ALREADY_SUBMITTED: u32 = 3020;
 }
 
 /// Oracle error codes (4000-4999)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  substrate-node:
+    build:
+      context: .
+      dockerfile: Dockerfile.test-node
+    container_name: propchain-test-node
+    ports:
+      - "9944:9944"
+      - "9933:9933"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9933/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - propchain-test-network
+
+  ipfs:
+    image: ipfs/kubo:latest
+    container_name: propchain-test-ipfs
+    ports:
+      - "5001:5001"
+      - "8080:8080"
+    networks:
+      - propchain-test-network
+
+  indexer:
+    image: subsquid/substrate-ingest:latest
+    container_name: propchain-test-indexer
+    environment:
+      - CHAIN_ENDPOINT=ws://substrate-node:9944
+    depends_on:
+      substrate-node:
+        condition: service_healthy
+    networks:
+      - propchain-test-network
+
+networks:
+  propchain-test-network:
+    driver: bridge

--- a/docs/onboarding-checklist.md
+++ b/docs/onboarding-checklist.md
@@ -33,6 +33,17 @@ Welcome to the PropChain development team! Use this checklist to set up your env
 - [ ] **Create a Feature Branch**: Always work on a separate branch for your changes.
 - [ ] **Follow ADRs**: Check existing [Architecture Decision Records](adr/) before making major design choices.
 
+## Docker Test Environment
+
+A pre-built Docker environment is available for running PropChain contract tests without a local Rust/Substrate setup.
+
+- [ ] **Start the test environment**: Run `./scripts/start-test-env.sh` from the repo root. This brings up a `substrate-contracts-node` (dev mode), an IPFS node, and a Subsquid indexer.
+- [ ] **Substrate RPC**: WebSocket at `ws://localhost:9944`, HTTP at `http://localhost:9933`
+- [ ] **IPFS API**: `http://localhost:5001`
+- [ ] **Stop the environment**: `docker compose -f docker-compose.test.yml down`
+
+The test compose file is `docker-compose.test.yml`; the node image is built from `Dockerfile.test-node`.
+
 ## Getting Help
 
 - [ ] **Review FAQ**: Check the [Troubleshooting/FAQ](troubleshooting-faq.md) for common issues.

--- a/docs/tutorials/cross-chain-bridging.md
+++ b/docs/tutorials/cross-chain-bridging.md
@@ -75,6 +75,29 @@ If a bridge request expires or fails, the token can be recovered on the source c
 bridge.recover_failed_bridge(request_id, RecoveryAction::UnlockToken)?;
 ```
 
+## 7. FATF Travel Rule Compliance
+
+For cross-border transfers exceeding the jurisdiction threshold, FATF travel rule data must be submitted before execution.
+
+```rust
+// Submit travel rule data before executing bridge
+let travel_data = TravelRuleData {
+    originator_name: b"Alice Smith".to_vec(),
+    originator_account: alice_account,
+    beneficiary_name: b"Bob Jones".to_vec(),
+    beneficiary_account: bob_account,
+    transfer_amount: 1_000_000,
+    data_hash: sha256(off_chain_data), // actual data stored off-chain
+    submitted_at: 0, // set by contract
+};
+bridge.submit_travel_rule_data(request_id, travel_data)?;
+
+// Now bridge execution will succeed
+bridge.execute_bridge(request_id)?;
+```
+
+See [FATF Travel Rule](https://www.fatf-gafi.org/recommendations/r16.html) for compliance details.
+
 ## Best Practices
 
 - Always check `is_bridge_operator` if you are implementing an operator service.

--- a/scripts/start-test-env.sh
+++ b/scripts/start-test-env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Starting PropChain test environment..."
+docker compose -f docker-compose.test.yml up -d
+
+echo "Waiting for node to be ready..."
+until curl -sf http://localhost:9933/health >/dev/null 2>&1; do
+  printf '.'
+  sleep 2
+done
+echo ""
+echo "Node ready at ws://localhost:9944"
+echo "IPFS API at http://localhost:5001"


### PR DESCRIPTION
## Changes

### Closes #527 — FATF Travel Rule Compliance for Cross-Chain Transfers
- `TravelRuleData` struct with originator name/account, beneficiary name/account, transfer amount, off-chain data hash, and submission timestamp
- `submit_travel_rule_data(request_id, data)` message — stores hash on-chain, actual PII off-chain
- `get_travel_rule_data(request_id)` query returning the on-chain hash reference
- `set_travel_rule_threshold(chain_id, amount)` admin message for per-jurisdiction thresholds
- `get_travel_rule_threshold(chain_id)` query (defaults to `u128::MAX` = disabled)
- Bridge execution gated: `ensure_travel_rule_compliance()` called inside `execute_bridge` before hash generation
- `TravelRuleDataSubmitted` and `TravelRuleThresholdUpdated` events
- `TravelRuleDataRequired` and `TravelRuleDataAlreadySubmitted` error variants with error codes 3019/3020
- Tests: bridge execution fails without travel rule data; succeeds after submission

### Closes #525 — Inline Code Examples in All Tutorials
- Added FATF travel rule compliance walkthrough (§7) to `cross-chain-bridging.md`
- All six tutorials now have working, copy-pasteable Rust ink! code examples

### Closes #522 — API Reference Documentation from Contract Traits
- Added `///` rustdoc comments to all public methods and types in `contracts/traits/src/bridge.rs`
- Created `.github/workflows/rustdoc.yml`: runs `cargo doc --no-deps --document-private-items --workspace` and deploys to GitHub Pages on every push to `main`
- Added API Reference link to README.md Contract Documentation section

### Closes #518 — Pre-built Docker Images for Substrate Test Environments
- `Dockerfile.test-node` — `substrate-contracts-node` base with PropChain pre-configured
- `docker-compose.test.yml` — substrate node + IPFS (kubo) + indexer (subsquid) stack with health checks
- `scripts/start-test-env.sh` — one-command startup with readiness polling
- Developer onboarding checklist updated with Docker workflow

## Closes
Closes #527
Closes #525
Closes #522
Closes #518