### PR TITLE
feat(dex): add slippage guard for sandwich resistance and concentrated liquidity positions

### DIFF
--- a/contracts/dex/src/concentrated_liquidity.rs
+++ b/contracts/dex/src/concentrated_liquidity.rs
@@ -1,0 +1,51 @@
+#[derive(Clone, Debug, PartialEq)]
+pub struct LiquidityPosition {
+    pub owner: [u8; 32],
+    pub pair_id: u64,
+    pub lower_tick: i32,
+    pub upper_tick: i32,
+    pub liquidity: u128,
+}
+
+impl LiquidityPosition {
+    pub fn new(owner: [u8; 32], pair_id: u64, lower_tick: i32, upper_tick: i32, liquidity: u128) -> Option<Self> {
+        if lower_tick >= upper_tick || liquidity == 0 { return None; }
+        Some(Self { owner, pair_id, lower_tick, upper_tick, liquidity })
+    }
+
+    pub fn is_active(&self, current_tick: i32) -> bool {
+        current_tick >= self.lower_tick && current_tick < self.upper_tick
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const OWNER: [u8; 32] = [1u8; 32];
+
+    #[test]
+    fn active_when_tick_in_range() {
+        let pos = LiquidityPosition::new(OWNER, 1, -100, 100, 1_000).unwrap();
+        assert!(pos.is_active(0));
+        assert!(pos.is_active(-100));
+        assert!(!pos.is_active(100));
+    }
+
+    #[test]
+    fn invalid_range_returns_none() {
+        assert!(LiquidityPosition::new(OWNER, 1, 100, 100, 1_000).is_none());
+        assert!(LiquidityPosition::new(OWNER, 1, 100, -100, 1_000).is_none());
+    }
+
+    #[test]
+    fn zero_liquidity_returns_none() {
+        assert!(LiquidityPosition::new(OWNER, 1, -100, 100, 0).is_none());
+    }
+
+    #[test]
+    fn inactive_outside_range() {
+        let pos = LiquidityPosition::new(OWNER, 1, 0, 50, 500).unwrap();
+        assert!(!pos.is_active(-1));
+        assert!(!pos.is_active(50));
+    }
+}

--- a/contracts/dex/src/slippage_guard.rs
+++ b/contracts/dex/src/slippage_guard.rs
@@ -1,0 +1,42 @@
+pub fn check_slippage(expected_out: u128, actual_out: u128, max_bps: u32) -> Result<(), SlippageError> {
+    if expected_out == 0 { return Err(SlippageError::ZeroExpected); }
+    let loss = expected_out.saturating_mul(max_bps as u128).saturating_div(10_000);
+    if actual_out < expected_out.saturating_sub(loss) {
+        return Err(SlippageError::Exceeded);
+    }
+    Ok(())
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SlippageError { Exceeded, ZeroExpected }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn within_tolerance_is_ok() { assert!(check_slippage(1000, 995, 50).is_ok()); }
+
+    #[test]
+    fn exceeding_tolerance_errors() {
+        assert_eq!(check_slippage(1000, 900, 50), Err(SlippageError::Exceeded));
+    }
+
+    #[test]
+    fn exact_boundary_accepted() {
+        // 1% of 1000 = 10; min acceptable = 990
+        assert!(check_slippage(1000, 990, 100).is_ok());
+        assert_eq!(check_slippage(1000, 989, 100), Err(SlippageError::Exceeded));
+    }
+
+    #[test]
+    fn zero_expected_errors() {
+        assert_eq!(check_slippage(0, 0, 100), Err(SlippageError::ZeroExpected));
+    }
+
+    #[test]
+    fn zero_slippage_requires_exact_output() {
+        assert!(check_slippage(1000, 1000, 0).is_ok());
+        assert_eq!(check_slippage(1000, 999, 0), Err(SlippageError::Exceeded));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds explicit slippage-check helper for sandwich-attack resistance on low-liquidity pools
- Adds Uniswap v3-style concentrated liquidity position type coexisting with the v2 pool

## Changes

- `contracts/dex/src/slippage_guard.rs` - check_slippage validates actual output is within caller-specified max deviation
- `contracts/dex/src/concentrated_liquidity.rs` - LiquidityPosition with tick-range validation and is_active predicate

closes #600
closes #599