### PR TITLE
feat(staking+governance): add validator unbonding tiers and on-chain treasury with spend limits

### DIFF
--- a/contracts/governance/src/treasury.rs
+++ b/contracts/governance/src/treasury.rs
@@ -1,0 +1,55 @@
+#[derive(Debug, PartialEq)]
+pub enum TreasuryError { NotApproved, ExceedsSpendLimit, InsufficientFunds }
+
+pub struct Treasury { balance: u128, spend_limit: u128 }
+
+impl Treasury {
+    pub fn new(balance: u128, spend_limit: u128) -> Self { Self { balance, spend_limit } }
+    pub fn deposit(&mut self, amount: u128) { self.balance = self.balance.saturating_add(amount); }
+    pub fn balance(&self) -> u128 { self.balance }
+
+    pub fn release(&mut self, approved: bool, amount: u128) -> Result<u128, TreasuryError> {
+        if !approved { return Err(TreasuryError::NotApproved); }
+        if amount > self.spend_limit { return Err(TreasuryError::ExceedsSpendLimit); }
+        if amount > self.balance { return Err(TreasuryError::InsufficientFunds); }
+        self.balance = self.balance.saturating_sub(amount);
+        Ok(amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_within_limit() {
+        let mut t = Treasury::new(10_000, 5_000);
+        assert_eq!(t.release(true, 3_000).unwrap(), 3_000);
+        assert_eq!(t.balance(), 7_000);
+    }
+
+    #[test]
+    fn exceeds_spend_limit() {
+        let mut t = Treasury::new(10_000, 5_000);
+        assert_eq!(t.release(true, 6_000), Err(TreasuryError::ExceedsSpendLimit));
+    }
+
+    #[test]
+    fn unapproved_proposal_rejected() {
+        let mut t = Treasury::new(10_000, 5_000);
+        assert_eq!(t.release(false, 100), Err(TreasuryError::NotApproved));
+    }
+
+    #[test]
+    fn insufficient_funds() {
+        let mut t = Treasury::new(100, 5_000);
+        assert_eq!(t.release(true, 200), Err(TreasuryError::InsufficientFunds));
+    }
+
+    #[test]
+    fn deposit_increases_balance() {
+        let mut t = Treasury::new(0, 1_000);
+        t.deposit(500);
+        assert_eq!(t.balance(), 500);
+    }
+}

--- a/contracts/staking/src/unbonding_tiers.rs
+++ b/contracts/staking/src/unbonding_tiers.rs
@@ -1,0 +1,50 @@
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ValidatorTier { A, B, C }
+
+impl ValidatorTier {
+    pub fn unbonding_secs(&self) -> u64 {
+        match self {
+            Self::A => 28 * 24 * 3600,
+            Self::B => 14 * 24 * 3600,
+            Self::C =>  7 * 24 * 3600,
+        }
+    }
+}
+
+pub fn unlock_at(staked_at: u64, tier: ValidatorTier) -> u64 {
+    staked_at.saturating_add(tier.unbonding_secs())
+}
+
+pub fn is_unbonded(staked_at: u64, tier: ValidatorTier, now: u64) -> bool {
+    now >= unlock_at(staked_at, tier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tier_a_28_days() {
+        assert_eq!(ValidatorTier::A.unbonding_secs(), 28 * 86_400);
+        assert!(!is_unbonded(0, ValidatorTier::A, 27 * 86_400));
+        assert!(is_unbonded(0, ValidatorTier::A, 28 * 86_400));
+    }
+
+    #[test]
+    fn tier_b_14_days() {
+        assert!(is_unbonded(0, ValidatorTier::B, 14 * 86_400));
+        assert!(!is_unbonded(0, ValidatorTier::B, 13 * 86_400));
+    }
+
+    #[test]
+    fn tier_c_7_days() {
+        assert!(is_unbonded(1000, ValidatorTier::C, 1000 + 7 * 86_400));
+        assert!(!is_unbonded(1000, ValidatorTier::C, 1000 + 6 * 86_400));
+    }
+
+    #[test]
+    fn tiers_ordered_descending() {
+        assert!(ValidatorTier::A.unbonding_secs() > ValidatorTier::B.unbonding_secs());
+        assert!(ValidatorTier::B.unbonding_secs() > ValidatorTier::C.unbonding_secs());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds per-validator-class unbonding tiers (Tier A: 28 days, B: 14 days, C: 7 days)
- Adds on-chain treasury contract with per-proposal spend limits

## Changes

- `contracts/staking/src/unbonding_tiers.rs` - ValidatorTier enum with unbonding_secs() and unlock_at/is_unbonded helpers
- `contracts/governance/src/treasury.rs` - Treasury with deposit/release enforcing spend limits

closes #608
closes #604