### PR TITLE
security(governance)+perf(dex): quorum regression detector and memoized swap path cache

### DIFF
--- a/contracts/dex/src/path_cache.rs
+++ b/contracts/dex/src/path_cache.rs
@@ -1,0 +1,51 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PathKey { pub from_token: u64, pub to_token: u64 }
+
+pub struct PathCache {
+    entries: alloc::vec::Vec<(PathKey, alloc::vec::Vec<u64>)>,
+    hits: u64,
+    misses: u64,
+}
+
+impl PathCache {
+    pub fn new() -> Self { Self { entries: alloc::vec::Vec::new(), hits: 0, misses: 0 } }
+
+    pub fn get(&mut self, key: &PathKey) -> Option<alloc::vec::Vec<u64>> {
+        match self.entries.iter().find(|(k, _)| k == key).map(|(_, p)| p.clone()) {
+            Some(p) => { self.hits += 1; Some(p) }
+            None => { self.misses += 1; None }
+        }
+    }
+
+    pub fn insert(&mut self, key: PathKey, path: alloc::vec::Vec<u64>) {
+        self.entries.retain(|(k, _)| k != &key);
+        self.entries.push((key, path));
+    }
+
+    pub fn hits(&self) -> u64 { self.hits }
+    pub fn misses(&self) -> u64 { self.misses }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn miss_then_hit() {
+        let mut c = PathCache::new();
+        let k = PathKey { from_token: 1, to_token: 5 };
+        assert!(c.get(&k).is_none());
+        c.insert(k.clone(), alloc::vec![1, 2, 3, 4, 5]);
+        assert_eq!(c.get(&k), Some(alloc::vec![1, 2, 3, 4, 5]));
+        assert_eq!(c.hits(), 1); assert_eq!(c.misses(), 1);
+    }
+
+    #[test]
+    fn insert_overwrites_existing_key() {
+        let mut c = PathCache::new();
+        let k = PathKey { from_token: 1, to_token: 3 };
+        c.insert(k.clone(), alloc::vec![1, 2, 3]);
+        c.insert(k.clone(), alloc::vec![1, 3]);
+        assert_eq!(c.get(&k), Some(alloc::vec![1, 3]));
+    }
+}

--- a/contracts/monitoring/src/quorum_guard.rs
+++ b/contracts/monitoring/src/quorum_guard.rs
@@ -1,0 +1,55 @@
+#[derive(Clone, Debug)]
+pub struct ProposalParticipation { pub proposal_id: u64, pub participation_bps: u32 }
+
+pub struct QuorumGuard {
+    history: alloc::vec::Vec<ProposalParticipation>,
+    warning_threshold_bps: u32,
+}
+
+impl QuorumGuard {
+    pub fn new(warning_threshold_bps: u32) -> Self {
+        Self { history: alloc::vec::Vec::new(), warning_threshold_bps }
+    }
+
+    pub fn record(&mut self, proposal_id: u64, participation_bps: u32) -> bool {
+        let warned = self.history.last()
+            .map(|prev| prev.participation_bps >= self.warning_threshold_bps && participation_bps < self.warning_threshold_bps)
+            .unwrap_or(false);
+        self.history.push(ProposalParticipation { proposal_id, participation_bps });
+        warned
+    }
+
+    pub fn history_len(&self) -> usize { self.history.len() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_warning_on_first_proposal() {
+        let mut g = QuorumGuard::new(500);
+        assert!(!g.record(1, 300));
+    }
+
+    #[test]
+    fn warns_when_participation_drops_below_threshold() {
+        let mut g = QuorumGuard::new(500);
+        g.record(1, 800);
+        assert!(g.record(2, 300));
+    }
+
+    #[test]
+    fn no_warning_when_staying_above_threshold() {
+        let mut g = QuorumGuard::new(500);
+        g.record(1, 800);
+        assert!(!g.record(2, 600));
+    }
+
+    #[test]
+    fn history_accumulates() {
+        let mut g = QuorumGuard::new(500);
+        g.record(1, 800); g.record(2, 300);
+        assert_eq!(g.history_len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds quorum regression detector that emits a warning when consecutive proposal participation drops below threshold
- Adds memoized swap path cache to avoid recomputing intermediate paths on every >5-hop call

## Changes

- `contracts/monitoring/src/quorum_guard.rs` - QuorumGuard records participation history and returns warning flag on regression
- `contracts/dex/src/path_cache.rs` - PathCache keyed by (from_token, to_token) with hit/miss counters

closes #605
closes #598