### PR TITLE
docs(lending): add rustdoc headers to three test modules

### DIFF
--- a/contracts/lending/README.md
+++ b/contracts/lending/README.md
@@ -95,6 +95,21 @@ contract.execute_proposal(proposal_id)?;
 cargo test
 ```
 
+### Test Module Layout
+
+All tests live in `contracts/lending/src/lib.rs` and are split into three
+`#[cfg(test)]` modules, each with a focused scope:
+
+| Module | Purpose |
+|--------|---------|
+| `tests` | Core unit tests covering the full contract lifecycle: collateral, pools, margin positions, loan underwriting, servicer integration, loan restructuring, multi-collateral pledging (#588), yield farming, governance, and credit scoring. **New tests for contract messages should go here.** |
+| `lending_admin_rotation_tests` | Isolated tests for the two-step time-locked admin rotation flow (Issue #496). Kept separate to avoid polluting the main suite with the specific caller-permutation setup these tests require. |
+| `storage_derivation_tests` | Compile-time assertions (Issue #589) that every public storage type implements `Encode + Decode + TypeInfo + StorageLayout`. Failures are type-checker errors, not runtime failures. Add a new `assert_storage_type::<MyNewType>();` call here whenever a new storage struct is introduced. |
+
+There is also a regression test file at `src/test.rs` (included as
+`mod lending_regression_test`) that covers the JIT interest-accrual
+behaviour documented in the stale-write TODO.
+
 ## Architecture
 
 The lending platform is built as an ink! smart contract with the following components:

--- a/contracts/lending/src/lib.rs
+++ b/contracts/lending/src/lib.rs
@@ -1834,6 +1834,14 @@ pub use crate::propchain_lending::{
     LendingError, LoanServicer, LoanStatus, PaymentSchedule, PaymentScheduleStatus, PropertyLending,
 };
 
+/// Core unit tests for the [`PropertyLending`] contract.
+///
+/// Covers the full lifecycle of lending operations: collateral assessment,
+/// pool management, margin positions, loan application and underwriting,
+/// servicer integration, loan restructuring, multi-collateral pledging,
+/// yield farming, on-chain governance proposals, and credit-score
+/// computation.  Extend this module when adding new contract messages or
+/// when a bug fix requires a regression guard.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2277,6 +2285,13 @@ mod tests {
     }
 }
 
+/// Admin key-rotation tests for the [`PropertyLending`] contract (Issue #496).
+///
+/// Validates the two-step, time-locked admin rotation flow: requesting,
+/// confirming after the cooldown period, cancelling by either party, and
+/// blocking unauthorized callers.  These tests are intentionally isolated
+/// from the main `tests` module so that rotation-specific setup (different
+/// caller permutations) does not add noise to general lending tests.
 // =========================================================================
 // ADMIN KEY ROTATION TESTS (Issue #496) — Lending
 // =========================================================================
@@ -2374,6 +2389,14 @@ mod lending_admin_rotation_tests {
     }
 }
 
+/// Storage-trait derivation assertion tests (Issue #589).
+///
+/// Confirms that every public type stored in [`PropertyLending`] implements
+/// all four required derives: [`scale::Encode`], [`scale::Decode`],
+/// [`scale_info::TypeInfo`], and [`ink::storage::traits::StorageLayout`].
+/// Compile-time failures here mean a newly introduced struct is missing a
+/// `#[derive(...)]` annotation.  No runtime logic is tested; the value of
+/// these tests is entirely in the type-checker.
 // =========================================================================
 // #589: Storage trait derivation assertion tests
 // =========================================================================

--- a/contracts/lending/src/lib.rs
+++ b/contracts/lending/src/lib.rs
@@ -2285,6 +2285,10 @@ mod tests {
     }
 }
 
+// =========================================================================
+// ADMIN KEY ROTATION TESTS (Issue #496) — Lending
+// =========================================================================
+
 /// Admin key-rotation tests for the [`PropertyLending`] contract (Issue #496).
 ///
 /// Validates the two-step, time-locked admin rotation flow: requesting,
@@ -2292,10 +2296,6 @@ mod tests {
 /// blocking unauthorized callers.  These tests are intentionally isolated
 /// from the main `tests` module so that rotation-specific setup (different
 /// caller permutations) does not add noise to general lending tests.
-// =========================================================================
-// ADMIN KEY ROTATION TESTS (Issue #496) — Lending
-// =========================================================================
-
 #[cfg(test)]
 mod lending_admin_rotation_tests {
     use super::propchain_lending::{LendingError, PropertyLending};
@@ -2389,6 +2389,10 @@ mod lending_admin_rotation_tests {
     }
 }
 
+// =========================================================================
+// #589: Storage trait derivation assertion tests
+// =========================================================================
+
 /// Storage-trait derivation assertion tests (Issue #589).
 ///
 /// Confirms that every public type stored in [`PropertyLending`] implements
@@ -2397,10 +2401,6 @@ mod lending_admin_rotation_tests {
 /// Compile-time failures here mean a newly introduced struct is missing a
 /// `#[derive(...)]` annotation.  No runtime logic is tested; the value of
 /// these tests is entirely in the type-checker.
-// =========================================================================
-// #589: Storage trait derivation assertion tests
-// =========================================================================
-
 #[cfg(test)]
 mod storage_derivation_tests {
     use super::propchain_lending::{


### PR DESCRIPTION
## Summary

Fixes #785

`contracts/lending/src/lib.rs` contains three `#[cfg(test)]` modules whose purpose was undocumented, making it unclear which module to extend for new tests.

## Changes

### `contracts/lending/src/lib.rs`

Added a rustdoc comment above each module:

- **`mod tests`** — describes coverage scope: collateral, pools, margin positions, loan underwriting, servicer integration, loan restructuring, multi-collateral (#588), yield farming, governance, and credit scoring. Notes this is where new message tests go.
- **`mod lending_admin_rotation_tests`** — explains the Issue #496 two-step admin rotation scope and why it is isolated from the main suite.
- **`mod storage_derivation_tests`** — explains the Issue #589 compile-time nature of the assertions and instructs contributors to add a new `assert_storage_type` call when introducing a new storage struct.

### `contracts/lending/README.md`

Added a **Test Module Layout** section with a three-row table summarising each module's purpose and instructions for where to add different kinds of tests.  Also documents the `src/test.rs` regression file.

## Acceptance Criteria (from issue)
- [x] Each block carries a 2-line (or more) rustdoc header
- [x] `cargo doc --no-deps` would render descriptions (doc comments are on the `mod` items)
- [x] README mentions the layout of all test files