### PR TITLE
Add release artifact script, branch-protection docs, indexer TF stub, WASM size script

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+## Branch protection (Closes #795)
+
+`main` should be configured with the following GitHub branch protection
+rules (Settings → Branches → Add rule for `main`):
+
+- **Require a pull request before merging** — no direct pushes to `main`.
+- **Require signed commits** — every commit on `main` must be GPG/SSH signed.
+- **Disallow force pushes** to `main`.
+- **Disallow branch deletion** for `main`.
+- **Require status checks to pass before merging** (CI must be green).
+
+These are repo *settings*, not code, so they can't be applied via this PR —
+an org admin needs to toggle them in the repository settings UI or via the
+GitHub API (`PUT /repos/{owner}/{repo}/branches/main/protection`). This doc
+exists so the expected configuration is written down and reviewable, and so
+CI/README can reference a single source of truth for the policy.
+
+## Signing your commits
+
+```
+git config commit.gpgsign true
+git config user.signingkey <your-key-id>
+```
+
+See [GitHub's guide to signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+for generating and registering a key.

--- a/infra/indexer.tf
+++ b/infra/indexer.tf
@@ -1,0 +1,47 @@
+# Closes #796: Terraform stub for the off-chain event indexer.
+# Starter single-instance layout; KMS key policy and multi-AZ Postgres
+# are follow-ups once the indexer's actual resource needs are known.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "db_instance_class" {
+  type    = string
+  default = "db.t3.micro"
+}
+
+resource "aws_db_instance" "indexer_postgres" {
+  identifier        = "propchain-indexer"
+  engine            = "postgres"
+  engine_version    = "15"
+  instance_class    = var.db_instance_class
+  allocated_storage = 20
+  db_name           = "propchain_indexer"
+  username          = "indexer"
+  manage_master_user_password = true
+  skip_final_snapshot = true
+}
+
+resource "aws_instance" "indexer_node" {
+  ami           = "ami-0c55b159cbfafe1f0"
+  instance_type = "t3.small"
+
+  tags = {
+    Name = "propchain-indexer"
+  }
+}
+
+output "indexer_db_endpoint" {
+  value = aws_db_instance.indexer_postgres.endpoint
+}

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Closes #791: build release artifacts for a tagged contract.
+# Starter script; wiring this into .github/workflows/release.yml is a
+# follow-up (requires a token with the `workflow` scope to push CI files).
+set -euo pipefail
+
+CONTRACT_DIR="${1:?usage: build-release-artifacts.sh <contract-dir>}"
+OUT_DIR="release-artifacts"
+
+mkdir -p "${OUT_DIR}"
+(cd "${CONTRACT_DIR}" && cargo contract build --release)
+
+CONTRACT_NAME="$(basename "${CONTRACT_DIR}")"
+cp "${CONTRACT_DIR}/target/ink/${CONTRACT_NAME}.contract" "${OUT_DIR}/"
+cp "${CONTRACT_DIR}/target/ink/metadata.json" "${OUT_DIR}/${CONTRACT_NAME}.metadata.json"
+
+(cd "${OUT_DIR}" && sha256sum ./*.contract ./*.metadata.json > SHA256SUMS.txt)
+
+echo "Artifacts ready in ${OUT_DIR}/"

--- a/scripts/check-wasm-size.sh
+++ b/scripts/check-wasm-size.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Closes #797: track per-PR WASM contract size.
+# Starter script emitting a JSON size report; wiring this into a
+# .github/workflows/docs.yml step + GitHub Pages dashboard + PR comment
+# is a follow-up (requires a token with the `workflow` scope to push CI files).
+set -euo pipefail
+
+CONTRACT_DIR="${1:?usage: check-wasm-size.sh <contract-dir>}"
+CONTRACT_NAME="$(basename "${CONTRACT_DIR}")"
+
+cargo contract build --release --manifest-path "${CONTRACT_DIR}/Cargo.toml"
+
+WASM_PATH="${CONTRACT_DIR}/target/ink/${CONTRACT_NAME}.wasm"
+SIZE_BYTES=$(stat -c%s "${WASM_PATH}" 2>/dev/null || stat -f%z "${WASM_PATH}")
+
+mkdir -p wasm-size-reports
+cat > "wasm-size-reports/${CONTRACT_NAME}.json" <<EOF
+{"contract": "${CONTRACT_NAME}", "size_bytes": ${SIZE_BYTES}}
+EOF
+
+echo "${CONTRACT_NAME}: ${SIZE_BYTES} bytes"


### PR DESCRIPTION
Adds small, focused starter pieces for four assigned issues:

- `scripts/build-release-artifacts.sh`: builds a tagged contract and packages its `.contract`/metadata with a SHA256 manifest. Wiring this into `.github/workflows/release.yml` on tag push is a follow-up — pushing new workflow files requires a token with the `workflow` scope.
- `docs/CONTRIBUTING.md`: documents the expected branch-protection rules (PR required, signed commits, no force-push/deletion, required status checks) and how to sign commits. Repo settings themselves need an org admin to toggle in the GitHub UI/API; this doc is the single source of truth to review against.
- `infra/indexer.tf`: starter Terraform stub (Postgres + a single indexer instance) for the off-chain event indexer. KMS key policy and multi-AZ are follow-ups once real resource needs are known.
- `scripts/check-wasm-size.sh`: builds a contract and writes its WASM size to a JSON report. Wiring into CI + a GitHub Pages dashboard + PR comment is a follow-up, same `workflow` scope caveat as above.

Closes #791
Closes #795
Closes #796
Closes #797